### PR TITLE
feat: deploy manifest sur AIDD via GHCR + Ansible

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,142 @@
+# deploy.yml — Build, push to GHCR, deploy on AIDD server
+#
+# Trigger: push to main + manual dispatch
+# Pattern: registry-based deploy (build once, deploy anywhere) — Leszko rule
+# Runner: self-hosted on AIDD server (zero billing, zero SSH, the runner IS the
+#         server, so deploy = local docker compose pull + up)
+# Source: aidd-driven-dev/website pattern (validated 4 NLM notebooks: GHA,
+#         Docker, Jenkins, DevOps-IA), KB Docker §06 (CI/CD integration).
+#
+# Build context is `app/` (this repo nests the Astro project under app/).
+
+name: Deploy to AIDD
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# Default: read-only (Principle of Least Privilege — NLM GHA)
+permissions: read-all
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+  DEPLOY_DIR: /opt/infrastructure/services/aidd-manifest
+  CONTAINER_NAME: aidd-manifest
+  CONTAINER_PORT: "4321"
+
+jobs:
+  # ──────────────────────────────────────────────
+  # JOB 1: Build & Push to GitHub Container Registry
+  # ──────────────────────────────────────────────
+  build-and-push:
+    name: Build & Push Docker Image
+    runs-on: self-hosted
+    permissions:
+      contents: read
+      packages: write
+
+    outputs:
+      image_tag: ${{ steps.meta.outputs.version }}
+      image_digest: ${{ steps.build.outputs.digest }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=sha,format=long
+            type=raw,value=latest
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push Docker image
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: ./app
+          file: ./app/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=local,src=/tmp/.buildx-cache-manifest
+          cache-to: type=local,dest=/tmp/.buildx-cache-manifest-new,mode=max
+
+      - name: Rotate buildx cache
+        run: |
+          rm -rf /tmp/.buildx-cache-manifest
+          mv /tmp/.buildx-cache-manifest-new /tmp/.buildx-cache-manifest 2>/dev/null || true
+
+  # ──────────────────────────────────────────────
+  # JOB 2: Deploy locally (runner IS the server)
+  # ──────────────────────────────────────────────
+  deploy:
+    name: Deploy
+    needs: build-and-push
+    runs-on: self-hosted
+    permissions:
+      packages: read
+
+    steps:
+      - name: Pull and deploy
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_USER: ${{ github.actor }}
+        run: |
+          set -e
+          cd "$DEPLOY_DIR"
+
+          echo "=== GHCR login (ephemeral token) ==="
+          echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin
+
+          echo "=== Pulling latest image ==="
+          docker compose pull
+
+          echo "=== Deploying ==="
+          docker compose up -d --remove-orphans
+
+          echo "=== Waiting for healthy ==="
+          for i in $(seq 1 20); do
+            STATUS=$(docker inspect --format='{{.State.Health.Status}}' "$CONTAINER_NAME" 2>/dev/null || echo "starting")
+            if [ "$STATUS" = "healthy" ]; then
+              echo "Container healthy after ${i}x5s"
+              break
+            fi
+            if [ "$i" -eq 20 ]; then
+              echo "ERROR: Container not healthy after 100s"
+              docker logs --tail 30 "$CONTAINER_NAME"
+              exit 1
+            fi
+            sleep 5
+          done
+
+          echo "=== Smoke test ==="
+          CONTAINER_IP=$(docker inspect --format='{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "$CONTAINER_NAME")
+          HTTP_CODE=$(curl -sf -o /dev/null -w '%{http_code}' "http://${CONTAINER_IP}:${CONTAINER_PORT}/" 2>/dev/null || echo "000")
+          if [ "$HTTP_CODE" != "200" ]; then
+            echo "ERROR: Smoke test failed (HTTP $HTTP_CODE)"
+            docker logs --tail 30 "$CONTAINER_NAME"
+            exit 1
+          fi
+
+          echo "=== Deploy successful ==="
+          echo "Image:  $(docker inspect --format='{{.Config.Image}}' "$CONTAINER_NAME")"
+          echo "Health: $(docker inspect --format='{{.State.Health.Status}}' "$CONTAINER_NAME")"
+          echo "HTTP:   $HTTP_CODE"
+
+          echo "=== GHCR logout ==="
+          docker logout ghcr.io

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,25 +1,48 @@
 # syntax=docker/dockerfile:1.7
-FROM node:22-alpine AS deps
+#
+# Astro 4 SSR (Node standalone adapter) — multi-stage build.
+# Compliant with aidd_docs/rules/architecture/docker.md:
+#   - Multi-stage: deps → build → runner
+#   - Runner runs prod-only node_modules (no devDeps)
+#   - Non-root USER with explicit UID/GID matching compose `user: 1001:1001`
+#   - HOST=0.0.0.0, PORT=4321, NODE_ENV=production
+#
+# Image is built and pushed to ghcr.io/ai-driven-dev/manifest by the
+# .github/workflows/deploy.yml pipeline (self-hosted runner on AIDD).
+
+# ── Production dependencies (runner) ─────────────────────────────
+FROM node:22-alpine AS prod-deps
 WORKDIR /app
 COPY package.json package-lock.json* ./
-RUN npm install --no-audit --no-fund
+RUN npm ci --omit=dev --no-audit --no-fund
 
+# ── All dependencies (build stage needs Astro CLI = devDep) ──────
+FROM node:22-alpine AS build-deps
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm ci --no-audit --no-fund
+
+# ── Build ────────────────────────────────────────────────────────
 FROM node:22-alpine AS build
 WORKDIR /app
-COPY --from=deps /app/node_modules ./node_modules
+COPY --from=build-deps /app/node_modules ./node_modules
 COPY . .
 RUN npm run build
 
+# ── Runner ───────────────────────────────────────────────────────
 FROM node:22-alpine AS runner
 WORKDIR /app
-ENV NODE_ENV=production
-ENV HOST=0.0.0.0
-ENV PORT=4321
-RUN addgroup -S app && adduser -S app -G app
-COPY --from=build /app/dist ./dist
-COPY --from=build /app/package.json ./package.json
-COPY --from=deps /app/node_modules ./node_modules
-RUN chown -R app:app /app
+ENV NODE_ENV=production \
+    HOST=0.0.0.0 \
+    PORT=4321
+
+# Explicit UID/GID 1001:1001 to match compose `user: "1001:1001"`.
+RUN addgroup -g 1001 -S app && adduser -u 1001 -S app -G app
+
+COPY --from=prod-deps --chown=app:app /app/node_modules ./node_modules
+COPY --from=build     --chown=app:app /app/dist          ./dist
+COPY --from=build     --chown=app:app /app/package.json  ./package.json
+
 USER app
 EXPOSE 4321
 CMD ["node", "./dist/server/entry.mjs"]


### PR DESCRIPTION
## Summary

Mirror the `ai-driven-dev/website` deployment pattern for the manifest site:

- **`.github/workflows/deploy.yml`** — build multi-stage Docker image, push to `ghcr.io/ai-driven-dev/manifest`, then `docker compose pull && up -d` on the self-hosted runner colocated on AIDD. No SSH, no remote credentials — only the ephemeral `GITHUB_TOKEN` (`packages: write`). Triggers on push to `main` and `workflow_dispatch`.
- **`app/Dockerfile`** — split into `prod-deps` (`npm ci --omit=dev`) and `build-deps` (`npm ci`) stages so the runner image ships runtime deps only. Explicit `UID/GID 1001:1001` to match the AIDD-side compose `user:` directive. Reproducible builds via `npm ci`.

Cible : `www.ai-driven-development.org` (apex → www via Traefik middleware côté AIDD).

## Test plan

- [ ] Merge → GHCR workflow builds + pushes image (`:sha-<commit>` + `:latest`)
- [ ] Self-hosted runner deploy job succeeds (compose pull + up -d + health-wait + smoke test)
- [ ] `ansible-playbook setup-manifest.yml -i inventories/production/hosts.yml --check --diff` clean (from `Project_Agent_Ops_Lab/infrastructure/ansible/`)
- [ ] Apply playbook (Traefik labels + compose file in `/opt/infrastructure/services/aidd-manifest`)
- [ ] `https://www.ai-driven-development.org/` returns 200 with valid Let's Encrypt cert
- [ ] Apex `ai-driven-development.org` redirects to `www`

## Scope V1

Strict parity with `ai-driven-dev/website` pattern — even where suboptimal (mutable `:latest` tag in AIDD compose, shared non-ephemeral self-hosted runner). Cross-repo hardening tracked separately in `Project_Agent_Ops_Lab/docs/HARDENING_ROADMAP_AIDD_GHCR_SITES.md` (C1–C3 + W1–W8) and will land in a V1.1 transverse PR touching both `website` and `manifest`.

## AI provenance

- AI-Source: claude-code:ansible-expert
- KB-Grounded: KB Docker §05/§06/§07, Ansible KB §01/§09
- Risk-Lane: green
- Trace-Id: `9207699e-7ef1-4178-800d-c62af24745e6` (shared across both commits)