### PR TITLE
docs(signatories): add Baptiste Lafourcade

### DIFF
--- a/app/src/content/signatories/blafourcade.yml
+++ b/app/src/content/signatories/blafourcade.yml
@@ -1,0 +1,6 @@
+github: blafourcade
+name: Baptiste Lafourcade
+linkedin: https://www.linkedin.com/in/baptistelafourcade/
+affiliation: AI-Driven Dev
+signed_on: 2026-05-08
+statement: AI-Driven Development. Craft first, always.


### PR DESCRIPTION
Sign the AI-Driven Development manifest.

| field | value |
| --- | --- |
| github | blafourcade |
| name | Baptiste Lafourcade |
| affiliation | AI-Driven Dev |
| statement | AI-Driven Development. Craft first, always. |