### PR TITLE
ci(validate): run e2e in official Playwright container

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -44,6 +44,10 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+      # The container runs as root while the checkout is owned by another uid,
+      # so git refuses the repo ("dubious ownership"). The webServer prebuild
+      # (gen-signature-dates.mjs) needs git, so mark the workspace as safe.
+      - run: git config --global --add safe.directory '*'
       - uses: actions/setup-node@v6
         with:
           node-version: '24'

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -47,7 +47,7 @@ jobs:
       # The container runs as root while the checkout is owned by another uid,
       # so git refuses the repo ("dubious ownership"). The webServer prebuild
       # (gen-signature-dates.mjs) needs git, so mark the workspace as safe.
-      - run: git config --global --add safe.directory '*'
+      - run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - uses: actions/setup-node@v6
         with:
           node-version: '24'

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -28,12 +28,15 @@ jobs:
       - run: npm test
       - run: bash tests/check-component-loc.sh
 
-  # Separate, non-blocking job: the Playwright e2e checklist. The runner's
-  # egress to the Playwright CDN (and apt) stalls, so browser install is
-  # unreliable here; keeping e2e out of the required `build` check stops a
-  # runner/network issue from blocking merges. Run locally before pushing.
+  # Separate, non-blocking job: the Playwright e2e checklist. Downloading the
+  # browser on a bare runner stalls after 100% (the install never resolves),
+  # so we run inside the official Playwright image which ships the browsers
+  # pre-installed (PLAYWRIGHT_BROWSERS_PATH=/ms-playwright). No download, no
+  # stall. Tag must match the playwright version in app/package-lock.json.
   e2e:
     runs-on: ubuntu-latest
+    container:
+      image: mcr.microsoft.com/playwright:v1.59.1-noble
     defaults:
       run:
         working-directory: app
@@ -47,19 +50,4 @@ jobs:
           cache: 'npm'
           cache-dependency-path: app/package-lock.json
       - run: npm ci
-      - name: Cache Playwright browsers
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('app/package-lock.json') }}
-      - name: Install Playwright chromium
-        timeout-minutes: 9
-        run: |
-          for attempt in 1 2 3; do
-            echo "Playwright install attempt $attempt"
-            if timeout 150 npx playwright install chromium; then exit 0; fi
-            echo "attempt $attempt stalled/failed; retrying"
-            sleep 5
-          done
-          echo "all attempts failed"; exit 1
       - run: npm run test:checklist


### PR DESCRIPTION
## Why

The `e2e` job fails on every PR. Root cause (from CI log): `npx playwright install chromium` downloads the 170 MiB browser, reaches **100% in ~2s**, then **hangs ~148s after 100%** (the install never resolves) and is killed by the per-attempt `timeout 150`. All 3 retries fail identically.

## Fix

Run the `e2e` job inside the official Playwright image `mcr.microsoft.com/playwright:v1.59.1-noble` (tag matches `playwright@1.59.1` in `app/package-lock.json`). Browsers are pre-installed in the image (`/ms-playwright`), so the download/retry/cache dance is removed entirely.

## Test

This PR exists to validate the fix on real CI: watch the `e2e` check go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)