### PR TITLE
ci(security): scope CODEOWNERS to habilitated for injection vectors

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,10 @@
-# Default ownership for the public manifesto repository.
-* @ai-driven-dev/core-team
+# Security gate: only the `habilitated` maintainers (approve/merge, guard the
+# standard) own the code-execution vectors. A PR touching any of these paths
+# requires a habilitated review before merge. Signatory `.yml` files have no
+# owner here on purpose, so the high-volume signing flow is not gated.
+/.github/                 @ai-driven-dev/habilitated
+/app/scripts/             @ai-driven-dev/habilitated
+/app/package.json         @ai-driven-dev/habilitated
+/app/package-lock.json    @ai-driven-dev/habilitated
+/app/*.config.*           @ai-driven-dev/habilitated
+Dockerfile                @ai-driven-dev/habilitated


### PR DESCRIPTION
Scopes code ownership to the `habilitated` maintainer team (6, the approve/merge guard role) on the paths that execute code in CI or on the self-hosted deploy runner: workflows, scripts, dependency manifests, build config, Dockerfile.

Signatory `.yml` files stay unowned on purpose so the signing flow keeps only the standard review.

Prereq for enabling `require_code_owner_reviews` without gating the high-volume signatory PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)