### PR TITLE
docs(contributing): align review/merge with habilitated + ruleset

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,12 +53,18 @@ npm run build
 
 ## Review And Merge
 
-Anyone may open a PR. `main` is protected. Only the authorized maintainer team
-can merge.
+Anyone may open a pull request. External contributors fork the repo and open the
+PR from their fork, so no repository access is needed to contribute.
 
-The Core Team reviews contributions and preserves the canonical text. Minor
-fixes can be merged quickly. Manifesto changes need discussion and clear
-agreement.
+`main` is protected by a ruleset. Every PR needs one approval, a passing `build`
+check, and a code-owner review for changes that execute code (workflows,
+scripts, dependency manifests, build config, Dockerfile). Force-pushes and
+branch deletion are blocked.
+
+The **Habilitated** maintainer team merges. The **Core Team** reviews
+contributions and preserves the canonical text. Admins keep a pull-request-only
+bypass for emergencies. Minor fixes can be merged quickly; manifesto changes
+need discussion and clear agreement.
 
 ## Conduct
 


### PR DESCRIPTION
CONTRIBUTING claimed the Core Team merges; merge authority is now the **Habilitated** team (Core Team reviews only). Documents the ruleset gate and the admin PR-only bypass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)