### PR TITLE
ci(validate): cancel superseded runs on the same ref

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -5,6 +5,13 @@ on:
   push:
     branches: [main]
 
+# Cancel an in-progress run when a newer commit lands on the same ref (PR or
+# branch), so rapid pushes don't pile up redundant runs. Scoped per-ref, so
+# different PRs never cancel each other.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # Required check. Fast + reliable: build, unit tests, component LOC budget.
   build:


### PR DESCRIPTION
Adds a per-ref `concurrency` group with `cancel-in-progress: true` so a newer push to a PR/branch cancels its previous in-progress run instead of piling up. Scoped by ref, so different PRs never cancel each other.

`deploy.yml` is intentionally left untouched (cancelling a self-hosted deploy mid-run would risk a partial deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)