### PR TITLE
Add a public signature registry and refresh manifesto sections

### DIFF
--- a/.impeccable/critique/2026-06-24T11-10-02Z__app-src-pages-index-astro.md
+++ b/.impeccable/critique/2026-06-24T11-10-02Z__app-src-pages-index-astro.md
@@ -1,0 +1,94 @@
+---
+target: app/src/pages/index.astro
+total_score: 34
+p0_count: 0
+p1_count: 0
+timestamp: 2026-06-24T11-10-02Z
+slug: app-src-pages-index-astro
+---
+# Design Health Score
+
+| # | Heuristic | Score | Key Issue |
+|---|-----------|-------|-----------|
+| 1 | Visibility of System Status | 3 | Signing affordances are clear; animated reveal needed to keep content visible during load. |
+| 2 | Match System / Real World | 4 | The citable-standard metaphor fits the manifesto well. |
+| 3 | User Control and Freedom | 3 | Anchor links and GitHub exit are clear; long-scroll orientation depends on desktop index. |
+| 4 | Consistency and Standards | 4 | Tokens, spacing, and document sections are coherent. |
+| 5 | Error Prevention | 3 | Mobile overflow risk could cause accidental horizontal panning. |
+| 6 | Recognition Rather Than Recall | 3 | Values and principles are strongly structured; signature wall needed more robust mobile wrapping. |
+| 7 | Flexibility and Efficiency | 3 | Desktop sticky index works; mobile relies on linear reading. |
+| 8 | Aesthetic and Minimalist Design | 4 | Distinct standard/document register without generic AI landing tropes. |
+| 9 | Error Recovery | 3 | External signing path is explicit; no major in-page recovery issues found. |
+| 10 | Help and Documentation | 4 | GitHub/signing links and manifesto structure are direct. |
+| **Total** | | **34/40** | **Strong, with responsive robustness fixes applied.** |
+
+# Anti-Patterns Verdict
+
+The surface does not read as generic AI slop. The strongest qualities are the restrained black-and-blue document system, the citable structure, and the refusal of purple gradients, glass cards, and metric hero tropes.
+
+Deterministic scan: clean. `detect.mjs --json app/src/pages/index.astro app/src/components app/src/styles/sections app/src/styles/tokens.css` returned `[]`.
+
+Browser evidence: Playwright screenshots and DOM measurements found mobile horizontal overflow before fixes, mainly from full-width signature cards and focus panels with gutter bleed. Immediate screenshots also showed hero copy could be temporarily invisible while reveal animations completed.
+
+# Overall Impression
+
+The page already has a strong product-positioned brand register: a manifesto as a published standard. The biggest opportunity was not reinvention, but hardening: keep the visual conviction while removing fragile responsive behavior and animation-gated readability.
+
+# What's Working
+
+- The cover has a confident typographic identity and a single clear signing CTA.
+- The document layout makes the manifesto feel citable rather than promotional.
+- The palette is restrained but specific: ice paper, navy ink, electric blue accent.
+
+# Priority Issues
+
+## [P2] Animation-gated hero readability
+
+Why it matters: screenshots, slow tabs, or paused animations could show blank hero/CTA text during the first load moment.
+
+Fix: keep cover words visible by default and animate transform only.
+
+Status: fixed in `app/src/styles/sections/cover.css`.
+
+## [P2] Mobile horizontal overflow
+
+Why it matters: a manifesto should feel stable and readable on phones; horizontal panning undermines trust.
+
+Fix: remove horizontal focus-panel bleed, add `min-width: 0` / `max-width: 100%` to grid and panel children, and make signature cards fluid.
+
+Status: fixed in `values.css`, `principles.css`, `value-art.css`, `terminal.css`, and `signature.css`.
+
+## [P3] Display typography exceeded the skill ceiling
+
+Why it matters: the hero was visually strong but slightly over-scaled and tightly tracked, risking cramped letterforms and lower polish.
+
+Fix: lower the desktop and mobile clamp ceiling and relax letter-spacing to `-0.035em`.
+
+Status: fixed in `cover.css` and value folio spacing.
+
+## [P3] Values intro copy was awkward
+
+Why it matters: small grammar defects reduce authority on a standards page.
+
+Fix: rewrite the heading and lede to cleaner English.
+
+Status: fixed in `Values.astro`.
+
+# Persona Red Flags
+
+**First-time AI-assisted developer**: before the fix, the mobile page could feel horizontally unstable in the signature wall. That is now fixed; the main remaining risk is that the page is long and linear without the desktop index.
+
+**Engineering lead evaluating credibility**: grammar in the values intro and over-tight hero type weakened authority. Both were tightened.
+
+**Keyboard-only reader**: focus states and skip link are present. The critique did not find a blocking keyboard issue in the inspected surface.
+
+# Minor Observations
+
+- The decorative watermark still extends beyond the viewport visually on mobile, but it no longer creates page scroll width.
+- Desktop sticky index remains hidden on mobile; acceptable for now, but a compact section jumper could improve long-scroll navigation.
+- Terminal/code panels intentionally keep internal horizontal scrolling for preformatted code.
+
+# Questions to Consider
+
+- Should mobile get a compact section index, or is the manifesto intended to read strictly top-to-bottom there?
+- Should the signature wall be shortened or progressively expanded on mobile to reduce the very long final section?

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,99 @@
+# AGENTS.md
+
+This file provides guidance to Codex (Codex.ai/code) when working with code in this repository.
+
+## Ce que c'est
+
+Manifesto for AI-Driven Development — Astro 4 SSR app, dockerisée, avec store
+en mémoire (signatures, votes, feedback). Le worktree d'origine contenait un
+seul HTML monolithique : il a été migré vers `app/` (Astro + TypeScript +
+Vitest + Playwright). La migration est terminée — l'app Astro est désormais sa
+propre source de vérité (plus de parité 1:1 avec l'ancien `index.html`).
+
+Cousin de `../website/` (Astro, ai-driven-dev.fr) mais **totalement
+indépendant** : ne partage aucun asset ni config. Ne pas importer depuis
+`../website`.
+
+## Lancer / prévisualiser
+
+```bash
+# Dev (HMR)
+cd app && npm install && npm run dev
+
+# Production locale
+cd app && npm run build && PORT=4321 HOST=127.0.0.1 node ./dist/server/entry.mjs
+
+# Docker
+cd app && docker compose up -d --build
+# → http://localhost:4321
+```
+
+## Tests
+
+```bash
+cd app
+npm test                  # Vitest unit (store)
+npx playwright test       # Playwright e2e (api, sign, vote, visual)
+```
+
+## Architecture
+
+```
+app/
+├── Dockerfile, compose.yaml, .dockerignore
+├── astro.config.mjs       SSR + @astrojs/node standalone
+├── src/
+│   ├── content/           Données éditoriales : principles.ts, values.ts, terms.ts, seeds.ts
+│   ├── styles/
+│   │   ├── tokens.css     :root tokens oklch (uniquement)
+│   │   └── sections/*.css Styles par section (cover, values, principles, …)
+│   ├── lib/
+│   │   ├── store/         Interface + impl mémoire + provider singleton
+│   │   ├── api/client.ts  Fetch helpers typés (sign, vote, feedback, count)
+│   │   └── observers.ts   Reveal / terminal / value-art / parallax
+│   ├── components/
+│   │   ├── layout/Page.astro
+│   │   ├── sections/{Cover,Preamble,Values,Principles,Signature}.astro
+│   │   ├── values/{ValueArt,Quadrant}.astro
+│   │   ├── principles/{PrincipleGrid,PrincipleCard}.astro
+│   │   ├── terminal/TerminalAnim.astro
+│   │   ├── signature/{SignDialog,SignatureWall}.astro
+│   │   ├── voting/{VoteWidget,DownvoteDialog}.astro
+│   │   ├── tweaks/TweaksPanel.astro
+│   │   └── ClientApp.astro    Single client island (hydratation tweaks + sign + vote + observers)
+│   └── pages/
+│       ├── index.astro    Composition (≤ 60 LOC)
+│       └── api/
+│           ├── signatures.ts  GET count, POST sign
+│           ├── votes.ts       POST +1/-1
+│           └── feedback.ts    POST reason + alternative
+└── tests/
+    ├── check-component-loc.sh AC-6 — LOC budget
+    └── e2e/{api,sign,vote,visual}.spec.ts
+```
+
+## Règles d'architecture (voir `aidd_docs/rules/architecture/`)
+
+- `astro-components.md` — `.astro` ≤ 200 LOC, `index.astro` ≤ 60 LOC, VoteWidget réutilisé.
+- `api-routes.md` — JSON in/out, validation stricte, contrats versionnés.
+- `store-provider.md` — interface-first, swappable, framework-agnostic.
+- `styles-tokens.md` — `oklch()` uniquement, pas de hex/HSL hors `tokens.css`.
+- `docker.md` — multi-stage Node 22 alpine, non-root, port 4321.
+- `testing.md` — Vitest unit + Playwright e2e + régression visuelle du cover ≤ 1 % (snapshot Astro, plus de baseline).
+
+## Conventions
+
+- Couleurs : `oklch()` exclusivement, via variables CSS (`var(--accent)` etc.).
+- Données éditoriales : tableaux TypeScript dans `src/content/`, pas de hard-code dans le HTML.
+- Tweaks panel : écrit sur `documentElement` (indirection préservée).
+- Edit mode parent iframe : sentinelle `/*EDITMODE-BEGIN*/…/*EDITMODE-END*/`
+  préservée dans `src/components/ClientApp.astro` (ne pas renommer).
+
+## Édition du contenu
+
+- Ajouter/modifier un principe : `app/src/content/principles.ts`.
+- Ajouter/modifier une valeur : `app/src/content/values.ts` (le champ `quad` alimente le quadrant 2×2 de `Quadrant.astro`) + ASCII art dans `ValueArt.astro`.
+- Ajouter/modifier un terminal : `app/src/content/terms.ts`.
+- Modifier la palette par défaut : `app/src/styles/tokens.css`.
+
+Manifeste monolingue : anglais uniquement. Pas d'I18N.

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,33 @@
+# Product
+
+## Register
+
+brand
+
+## Users
+
+Software practitioners, engineering leads, product builders, and AI-assisted developers who want a shared standard for building software with AI while keeping human judgment, craft, and responsibility in the loop. They arrive to read, cite, share, or publicly sign the manifesto.
+
+## Product Purpose
+
+The site publishes the canonical Manifesto for AI-Driven Development, frames its four values and twelve principles, and turns agreement into a public Git-based signature. Success means visitors understand the standard quickly, trust the text enough to share or cite it, and can sign without ambiguity.
+
+## Brand Personality
+
+Precise, principled, and developer-native. The interface should feel like a citable standard with enough visual conviction to be memorable, not like a SaaS landing page or a generic AI tool.
+
+## Anti-references
+
+Avoid AI-product cliché: purple gradients, glass panels, hero metric blocks, generic dashboard chrome, decorative card grids, and empty "AI magic" language. Avoid editorial affectation that makes the manifesto feel like a magazine instead of a standard. Avoid hiding the text behind spectacle.
+
+## Design Principles
+
+- Treat the manifesto as the artifact: make the text readable, durable, and easy to cite.
+- Signal conviction without hype: strong hierarchy, restrained interaction, no generic AI theatrics.
+- Make signing feel public and intentional, not like a marketing conversion trick.
+- Keep developer trust high: visible structure, direct copy, clear GitHub affordances.
+- Preserve accessibility as part of the standard: keyboard paths, reduced motion, robust contrast, and responsive reading.
+
+## Accessibility & Inclusion
+
+Target WCAG AA for text contrast and interaction states. Motion must respect `prefers-reduced-motion`; the manifesto must remain readable with animations disabled, on narrow screens, and for keyboard-only users.

--- a/app/src/components/definition/VersusSchemas.astro
+++ b/app/src/components/definition/VersusSchemas.astro
@@ -8,7 +8,7 @@
   <!-- 1 — METHOD -->
   <figure class="vsch">
     <figcaption class="vsch-cap">Method</figcaption>
-    <svg class="vsch-svg" viewBox="0 0 300 196" role="img"
+    <svg class="vsch-svg" viewBox="0 0 300 214" role="img"
       aria-label="AIDD moves plan, build, review gate, prod and loops back to iterate; vibe coding jumps prompt straight to prod, then regenerates.">
       <defs>
         <marker id="m1a" markerWidth="8" markerHeight="8" refX="5.5" refY="3" orient="auto"><path d="M0 .5 L6 3 L0 5.5" class="ah-a"/></marker>
@@ -33,15 +33,15 @@
       <text x="196" y="92" class="lbl lbl--a">review</text>
       <text x="258" y="88" class="lbl">prod</text>
 
-      <line x1="16" y1="112" x2="284" y2="112" class="rule-faint"/>
+      <line x1="16" y1="116" x2="284" y2="116" class="rule-faint"/>
 
       <!-- Vibe track -->
-      <text x="20" y="132" class="tag tag--m">VIBE CODING</text>
-      <path d="M76 150 H224" class="seg" marker-end="url(#m1m)"/>
-      <circle cx="70" cy="150" r="4.5" class="stn-m"/>
-      <circle cx="230" cy="150" r="4.5" class="stn-m"/>
-      <text x="70" y="144" class="lbl">prompt</text>
-      <text x="230" y="144" class="lbl">prod</text>
+      <text x="20" y="142" class="tag tag--m">VIBE CODING</text>
+      <path d="M76 164 H224" class="seg" marker-end="url(#m1m)"/>
+      <circle cx="70" cy="164" r="4.5" class="stn-m"/>
+      <circle cx="230" cy="164" r="4.5" class="stn-m"/>
+      <text x="70" y="186" class="lbl">prompt</text>
+      <text x="230" y="186" class="lbl">prod</text>
     </svg>
     <p class="vsch-note">Do not care about code quality.</p>
   </figure>

--- a/app/src/components/layout/SpecIndex.astro
+++ b/app/src/components/layout/SpecIndex.astro
@@ -16,7 +16,7 @@ const count = (await getCollection('signatories')).length;
       </svg>
       <span class="si-word">AIDD</span>
     </span>
-    <span class="si-ver">v1.0</span>
+    <span class="si-ver">v1.1</span>
   </div>
   <nav class="si-nav">
     <a class="si-link" href="#definition" data-spy="definition">Definition</a>

--- a/app/src/components/sections/Cover.astro
+++ b/app/src/components/sections/Cover.astro
@@ -13,7 +13,7 @@
   <div class="cover-rule cover-rule-bottom" aria-hidden="true"></div>
 
   <div class="cover-stage">
-    <p class="cover-std reveal-word" style="--d:.02s">AIDD <span class="cs-sep">·</span> Manifesto <span class="cs-sep">·</span> v1.0 <span class="cs-sep">·</span> 2026</p>
+    <p class="cover-std reveal-word" style="--d:.02s">AIDD <span class="cs-sep">·</span> Manifesto <span class="cs-sep">·</span> v1.1 <span class="cs-sep">·</span> 2026</p>
 
     <h1 class="cover-title">
       <span class="line line-1"><span class="word reveal-word" style="--d:.12s">The</span></span>
@@ -28,9 +28,24 @@
     <div class="cover-foot reveal-word" style="--d:.72s">
       <p class="cover-lede">A standard for building software in the age of AI — written by developers, for developers.</p>
       <nav class="cover-cta" aria-label="Manifesto entry points">
-        <a class="cover-link cover-link-primary" href="#sign">Sign the manifesto</a>
+        <a class="cover-link cover-link-primary" href="#sign">
+          <span class="cover-link-icon cover-link-icon-aidd" aria-hidden="true">
+            <svg viewBox="0 0 100 100" focusable="false">
+              <line x1="8" y1="92" x2="28" y2="62" stroke="currentColor" stroke-width="14" stroke-linecap="round" />
+              <circle cx="42" cy="41" r="10" fill="currentColor" />
+              <line x1="60" y1="8" x2="92" y2="92" stroke="currentColor" stroke-width="22" stroke-linecap="round" />
+            </svg>
+          </span>
+          <span>Sign the manifesto</span>
+        </a>
         <a class="cover-link" href="https://github.com/ai-driven-dev/manifest" target="_blank" rel="noopener">
-          View on GitHub <span class="cl-ext" aria-hidden="true">↗</span>
+          <span class="cover-link-icon" aria-hidden="true">
+            <svg viewBox="0 0 16 16" focusable="false">
+              <path fill="currentColor" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8z"/>
+            </svg>
+          </span>
+          <span>View on GitHub</span>
+          <span class="cl-ext" aria-hidden="true">↗</span>
         </a>
       </nav>
     </div>

--- a/app/src/components/sections/Signature.astro
+++ b/app/src/components/sections/Signature.astro
@@ -1,20 +1,39 @@
 ---
+import { getCollection } from 'astro:content';
 import SignButton from '~/components/signature/SignButton.astro';
 import SignatureWall from '~/components/signature/SignatureWall.astro';
+
+const count = (await getCollection('signatories')).length;
+const registryCount = String(count).padStart(3, '0');
 ---
 <section id="sign" class="signature">
-  <div class="chapter-open reveal">
-    <div class="chapter-body">
-      <h2>Be part of the movement!</h2>
-      <div class="chapter-lede">
-        <svg class="fleuron" width="44" height="44" viewBox="0 0 44 44" fill="none" aria-hidden="true">
-          <path d="M22 4 C 28 14, 40 14, 40 22 C 40 30, 28 30, 22 40 C 16 30, 4 30, 4 22 C 4 14, 16 14, 22 4 Z" stroke="currentColor" stroke-width="1" fill="none"/>
-          <circle cx="22" cy="22" r="2" fill="currentColor"/>
-        </svg>
-        <p>
-        Be among the first to sign the <strong>AI-Driven Development Manifesto</strong> and help shape the future of software development.
-        </p>
+  <div class="chapter-open signature-open reveal">
+    <svg class="signature-open-mark" viewBox="0 0 100 100" aria-hidden="true" focusable="false">
+      <line class="som-bar-small" x1="8" y1="92" x2="28" y2="62" stroke="currentColor" stroke-width="14" stroke-linecap="round" />
+      <circle class="som-dot" cx="42" cy="41" r="10" fill="currentColor" />
+      <line class="som-bar-big" x1="60" y1="8" x2="92" y2="92" stroke="currentColor" stroke-width="22" stroke-linecap="round" />
+    </svg>
+
+    <div class="chapter-body signature-open-body">
+      <div class="signature-open-copy">
+        <p class="signature-kicker">Public signature registry</p>
+        <h2>Be part of the movement!</h2>
+        <div class="chapter-lede">
+          <svg class="fleuron" width="44" height="44" viewBox="0 0 44 44" fill="none" aria-hidden="true">
+            <path d="M22 4 C 28 14, 40 14, 40 22 C 40 30, 28 30, 22 40 C 16 30, 4 30, 4 22 C 4 14, 16 14, 22 4 Z" stroke="currentColor" stroke-width="1" fill="none"/>
+            <circle cx="22" cy="22" r="2" fill="currentColor"/>
+          </svg>
+          <p>
+          Be among the first to sign the <strong>AI-Driven Development Manifesto</strong> and help shape the future of software development.
+          </p>
+        </div>
       </div>
+
+      <aside class="signature-seal" aria-label={`${count} manifesto signatories`}>
+        <span class="signature-seal-label">AIDD registry</span>
+        <strong>{registryCount}</strong>
+        <span class="signature-seal-caption">{count === 1 ? 'signatory' : 'signatories'}</span>
+      </aside>
     </div>
   </div>
 

--- a/app/src/components/sections/Values.astro
+++ b/app/src/components/sections/Values.astro
@@ -6,13 +6,13 @@ import Icon from '~/components/Icon.astro';
 <section id="values" class="values">
   <div class="chapter-open reveal">
     <div class="chapter-body">
-      <h2> <span class="amp">4 values</span> of the<br> AI-Driven Development</h2>
+      <h2><span class="amp">4 values</span> of<br> AI-Driven Development</h2>
       <div class="chapter-lede">
         <svg class="fleuron" width="44" height="44" viewBox="0 0 44 44" fill="none" aria-hidden="true">
           <path d="M22 4 C 28 14, 40 14, 40 22 C 40 30, 28 30, 22 40 C 16 30, 4 30, 4 22 C 4 14, 16 14, 22 4 Z" stroke="currentColor" stroke-width="1" fill="none"/>
           <circle cx="22" cy="22" r="2" fill="currentColor"/>
         </svg>
-        <p>Despite being non technical, those values will guide you everytime you are using AI to code.</p>
+        <p>These non-technical values guide every AI-assisted coding session.</p>
       </div>
     </div>
   </div>

--- a/app/src/components/signature/SignatureWall.astro
+++ b/app/src/components/signature/SignatureWall.astro
@@ -27,49 +27,55 @@ const humanDate = (iso: string) => (iso ? dateFmt.format(new Date(`${iso}T00:00:
 
   {count > 0 && (
     <ul class="sig-grid" role="list">
-      {sigs.map((s) => (
-        <li class="sig-card">
-          <div class="sig-top">
-            <a
-              class="sig-link"
-              href={`https://github.com/${s.github}`}
-              target="_blank"
-              rel="noopener"
-              aria-label={`${s.name} on GitHub`}
-            >
-              <img
-                class="sig-avatar"
-                src={`https://github.com/${s.github}.png?size=128`}
-                alt=""
-                loading="lazy"
-                width="64"
-                height="64"
-              />
-              <span class="sig-meta">
-                <span class="sig-name">{s.name}</span>
-                {s.affiliation && <span class="sig-affil">{s.affiliation}</span>}
-              </span>
-            </a>
-            {s.linkedin && (
+      {sigs.map((s, index) => {
+        const registryNo = String(index + 1).padStart(3, '0');
+        return (
+          <li class="sig-card">
+            <div class="sig-top">
               <a
-                class="sig-linkedin"
-                href={s.linkedin}
+                class="sig-link"
+                href={`https://github.com/${s.github}`}
                 target="_blank"
                 rel="noopener"
-                aria-label={`${s.name} on LinkedIn`}
+                aria-label={`${s.name} on GitHub`}
               >
-                <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-                  <path fill="currentColor" d="M4.98 3.5C4.98 4.88 3.87 6 2.5 6S0 4.88 0 3.5 1.13 1 2.5 1s2.48 1.12 2.48 2.5zM.22 8h4.56v14H.22V8zm7.66 0h4.37v1.92h.06c.61-1.16 2.1-2.38 4.32-2.38 4.62 0 5.47 3.04 5.47 7v8.46h-4.55v-7.5c0-1.79-.03-4.09-2.49-4.09-2.5 0-2.88 1.95-2.88 3.96V22H7.88V8z"/>
-                </svg>
+                <img
+                  class="sig-avatar"
+                  src={`https://github.com/${s.github}.png?size=128`}
+                  alt=""
+                  loading="lazy"
+                  width="64"
+                  height="64"
+                />
+                <span class="sig-meta">
+                  <span class="sig-name">{s.name}</span>
+                  {s.affiliation && <span class="sig-affil">{s.affiliation}</span>}
+                </span>
               </a>
-            )}
-          </div>
-          {s.statement && <p class="sig-statement">{s.statement.trim()}</p>}
-          {s.signedAt && (
-            <time class="sig-date" datetime={s.signedAt}>Signed {humanDate(s.signedAt)}</time>
-          )}
-        </li>
-      ))}
+              {s.linkedin && (
+                <a
+                  class="sig-linkedin"
+                  href={s.linkedin}
+                  target="_blank"
+                  rel="noopener"
+                  aria-label={`${s.name} on LinkedIn`}
+                >
+                  <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                    <path fill="currentColor" d="M4.98 3.5C4.98 4.88 3.87 6 2.5 6S0 4.88 0 3.5 1.13 1 2.5 1s2.48 1.12 2.48 2.5zM.22 8h4.56v14H.22V8zm7.66 0h4.37v1.92h.06c.61-1.16 2.1-2.38 4.32-2.38 4.62 0 5.47 3.04 5.47 7v8.46h-4.55v-7.5c0-1.79-.03-4.09-2.49-4.09-2.5 0-2.88 1.95-2.88 3.96V22H7.88V8z"/>
+                  </svg>
+                </a>
+              )}
+            </div>
+            {s.statement && <p class="sig-statement">{s.statement.trim()}</p>}
+            <div class="sig-card-foot">
+              {s.signedAt && (
+                <time class="sig-date" datetime={s.signedAt}>Signed {humanDate(s.signedAt)}</time>
+              )}
+              <span class="sig-entry" aria-label={`Signature number ${index + 1}`}>#{registryNo}</span>
+            </div>
+          </li>
+        );
+      })}
     </ul>
   )}
 </div>

--- a/app/src/styles/sections/base.css
+++ b/app/src/styles/sections/base.css
@@ -85,6 +85,9 @@ summary:focus-visible{
 /* Skip link — visible only on focus */
 .skip-link{
   position: absolute; left: 12px; top: -100px; z-index: 100;
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
   padding: 10px 16px; background: var(--accent); color: var(--accent-ink);
   font-family: var(--sans); font-size: 12px; letter-spacing: 0.04em;
   text-decoration: none; border-radius: 4px;

--- a/app/src/styles/sections/cover.css
+++ b/app/src/styles/sections/cover.css
@@ -10,18 +10,41 @@
   overflow: hidden;
   isolation: isolate;
   border-bottom: 1px solid var(--rule);
+  background: var(--paper);
+}
+
+.cover::before{
+  content: "";
+  position: absolute;
+  top: clamp(40px, 7vh, 72px);
+  left: clamp(24px, 6vw, 96px);
+  width: clamp(92px, 14vw, 188px);
+  height: clamp(8px, 1vw, 13px);
+  background: var(--accent);
+  z-index: 4;
+  transform: scaleX(0);
+  transform-origin: left;
+  animation: cover-rule-draw 1.1s var(--ease-out) .35s forwards;
+}
+
+.cover::after{
+  content: "";
+  position: absolute;
+  inset: 0 0 0 58%;
+  background: var(--paper-3);
+  z-index: 0;
 }
 
 /* AIDD mark — faint watermark, parallax hook (transform set by JS). */
 .cover-watermark{
   position: absolute;
   left: 50%; top: 50%;
-  width: min(70vmin, 720px);
-  height: min(70vmin, 720px);
-  transform: translate(calc(-50% + 24vw), calc(-50% - 4vh));
-  color: oklch(from var(--ink) l c h / 0.05);
+  width: min(92vmin, 940px);
+  height: min(92vmin, 940px);
+  transform: translate(calc(-50% + 31vw), calc(-50% - 3vh));
+  color: oklch(from var(--accent) l c h / 0.13);
   pointer-events: none;
-  z-index: -1;
+  z-index: 1;
   user-select: none; -webkit-user-select: none;
   overflow: visible;
 }
@@ -38,7 +61,7 @@
 .cover-rule{
   position: absolute;
   left: clamp(24px, 6vw, 96px); right: clamp(24px, 6vw, 96px);
-  height: 1px; background: var(--rule);
+  height: 2px; background: oklch(from var(--ink) l c h / 0.14);
   z-index: 3; transform: scaleX(0); transform-origin: left;
   animation: cover-rule-draw 1.4s var(--ease-out) .15s forwards;
 }
@@ -46,14 +69,15 @@
 .cover-rule-bottom{ bottom: clamp(40px, 7vh, 72px); }
 @keyframes cover-rule-draw{ to{ transform: scaleX(1); } }
 
-.cover-stage{ position: relative; width: 100%; max-width: 1160px; }
+.cover-stage{ position: relative; width: 100%; max-width: 1280px; z-index: 2; }
 
 /* Standard header line. */
 .cover-std{
   font-family: var(--sans);
   font-size: clamp(11px, 1.05vw, 13px);
   letter-spacing: .2em; text-transform: uppercase;
-  color: var(--ink-3);
+  font-weight: 650;
+  color: var(--ink-2);
   margin-bottom: clamp(20px, 3vh, 34px);
 }
 .cover-std .cs-sep{ color: var(--accent); margin: 0 .35em; }
@@ -63,33 +87,34 @@
   font-family: var(--display);
   font-weight: 800;
   /* vh-aware so the hero always fits a single 100dvh fold on desktop */
-  font-size: clamp(44px, min(9vw, 13.5vh), 124px);
-  line-height: 0.9;
-  letter-spacing: -0.045em;
+  font-size: clamp(48px, min(8.6vw, 12vh), 96px);
+  line-height: 0.89;
+  letter-spacing: -0.035em;
   color: var(--ink);
-  max-width: 16ch;
+  max-width: 12ch;
   overflow-wrap: anywhere; min-width: 0;
+  text-wrap: balance;
 }
 .cover-title .line{ display: block; }
 .cover-title .word{ display: inline-block; }
 
 .reveal-word{
-  opacity: 0; transform: translateY(0.4em);
+  opacity: 1; transform: translateY(0.4em);
   animation: word-rise 0.95s var(--ease-out) forwards;
   animation-delay: var(--d, 0s);
 }
-@keyframes word-rise{ to{ opacity: 1; transform: none; } }
+@keyframes word-rise{ to{ transform: none; } }
 
-/* "Manifesto" line — slightly quieter, the descriptor. */
-.cover-title .for{ color: var(--ink-2); }
+/* "Manifesto" line — still secondary, but present enough to anchor the title. */
+.cover-title .for{ color: var(--ink); opacity: .76; }
 
 /* "AI-Driven" — one restrained accent moment: a thin accent underline sweeps in. */
 .cover-title .ai{ position: relative; display: inline-block; color: var(--ink); }
 .cover-title .ai-text{ position: relative; z-index: 1; }
 .cover-title .ai-strike{
   position: absolute;
-  left: 0.02em; right: 0.02em; bottom: 0.06em;
-  height: 0.07em;
+  left: 0.02em; right: 0.02em; bottom: 0.04em;
+  height: 0.1em;
   background: var(--accent);
   border-radius: 2px;
   transform: scaleX(0); transform-origin: left;
@@ -100,24 +125,25 @@
 
 /* Foot — lede + two entry links. */
 .cover-foot{
-  margin-top: clamp(32px, 5vh, 60px);
+  margin-top: clamp(34px, 5.5vh, 66px);
   display: flex; flex-direction: column;
   gap: clamp(20px, 3vh, 32px);
-  max-width: 56ch;
+  max-width: 50ch;
 }
 .cover-lede{
   font-family: var(--sans);
-  font-size: clamp(16px, 1.5vw, 21px);
-  line-height: 1.5;
-  color: var(--ink-2);
+  font-size: clamp(18px, 1.55vw, 22px);
+  line-height: 1.45;
+  color: var(--ink);
+  text-wrap: pretty;
 }
 .cover-cta{ display: flex; flex-wrap: wrap; gap: 14px 20px; align-items: center; }
 .cover-link{
   display: inline-flex; align-items: center; gap: .5em;
-  min-height: 44px; padding: 0 18px;
+  min-height: 50px; padding: 0 22px;
   font-family: var(--sans);
   font-size: clamp(14px, 1.1vw, 15px);
-  font-weight: 500; letter-spacing: -0.005em;
+  font-weight: 650; letter-spacing: 0;
   color: var(--ink); text-decoration: none;
   border: 1px solid var(--rule); border-radius: var(--radius-pill);
   transition: border-color .2s var(--ease-out), color .2s var(--ease-out), background .2s var(--ease-out);
@@ -130,22 +156,46 @@
 
 @media (max-width: 760px){
   .cover{ padding: clamp(64px, 12vh, 96px) clamp(20px, 6vw, 40px); }
-  .cover-rule{ left: clamp(20px, 6vw, 40px); right: clamp(20px, 6vw, 40px); }
-  .cover-title{ font-size: clamp(46px, 15vw, 92px); }
-  .cover-watermark{
-    width: min(120vmin, 520px); height: min(120vmin, 520px);
-    transform: translate(-50%, calc(-50% + 10vh));
-    color: oklch(from var(--ink) l c h / 0.04);
+  .cover::before{
+    left: clamp(20px, 6vw, 40px);
+    width: clamp(80px, 28vw, 128px);
   }
+  .cover::after{ inset: 62% 0 0 0; }
+  .cover-rule{ left: clamp(20px, 6vw, 40px); right: clamp(20px, 6vw, 40px); }
+  .cover-title{ font-size: clamp(44px, 13.5vw, 80px); line-height: 0.92; max-width: 11ch; }
+  .cover-watermark{
+    width: min(118vmin, 520px); height: min(118vmin, 520px);
+    transform: translate(calc(-50% + 16vw), calc(-50% + 13vh));
+    color: oklch(from var(--accent) l c h / 0.09);
+  }
+  .cover-lede{ max-width: 31ch; }
   .cover-cta{ width: 100%; }
   .cover-link{ flex: 1 1 auto; justify-content: center; }
 }
 
+@media (prefers-reduced-motion: reduce){
+  .cover::before,
+  .cover-rule,
+  .cover-watermark line,
+  .cover-watermark circle,
+  .reveal-word,
+  .cover-title .ai-strike{
+    animation: none !important;
+    transform: none !important;
+  }
+  .cover-watermark line,
+  .cover-watermark circle{
+    opacity: 1;
+  }
+}
+
 @media print{
   .cover{ height: auto; min-height: 0; padding: 0 0 16mm; page-break-after: always; border: none; }
+  .cover::before,
+  .cover::after{ display: none; }
   .cover-rule{ animation: none !important; transform: none !important; }
   .cover-watermark{ display: none; }
-  .cover-title{ font-size: clamp(48px, 10vw, 110px); }
+  .cover-title{ font-size: clamp(48px, 10vw, 96px); }
   .cover-title .word{ opacity: 1; transform: none; animation: none; }
   .cover-title .ai-strike{ transform: scaleX(1); animation: none; }
   .cover-foot{ opacity: 1; transform: none; animation: none; }

--- a/app/src/styles/sections/cover.css
+++ b/app/src/styles/sections/cover.css
@@ -140,19 +140,54 @@
 .cover-cta{ display: flex; flex-wrap: wrap; gap: 14px 20px; align-items: center; }
 .cover-link{
   display: inline-flex; align-items: center; gap: .5em;
-  min-height: 50px; padding: 0 22px;
+  min-height: 50px; padding: 8px 20px 8px 10px;
   font-family: var(--sans);
   font-size: clamp(14px, 1.1vw, 15px);
   font-weight: 650; letter-spacing: 0;
   color: var(--ink); text-decoration: none;
   border: 1px solid var(--rule); border-radius: var(--radius-pill);
-  transition: border-color .2s var(--ease-out), color .2s var(--ease-out), background .2s var(--ease-out);
+  transition:
+    border-color .2s var(--ease-out),
+    color .2s var(--ease-out),
+    background .2s var(--ease-out),
+    transform .2s var(--ease-out);
 }
-.cover-link:hover{ border-color: var(--ink); }
+.cover-link:hover{ border-color: var(--ink); transform: translateY(-1px); }
 .cover-link-primary{
   background: var(--accent); color: var(--accent-ink); border-color: var(--accent);
 }
 .cover-link-primary:hover{ border-color: var(--accent); filter: brightness(1.08); }
+.cover-link-icon{
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 6px;
+  background: var(--paper-2);
+  color: var(--ink);
+  flex: none;
+  box-shadow: 0 0 0 1px var(--rule);
+}
+.cover-link-primary .cover-link-icon{
+  background: var(--accent-ink);
+  color: var(--accent);
+  box-shadow: none;
+}
+.cover-link-icon svg{
+  width: 17px;
+  height: 17px;
+  overflow: visible;
+}
+.cover-link-icon-aidd svg{
+  width: 21px;
+  height: 21px;
+}
+.cover-link .cl-ext{
+  margin-left: 2px;
+  transition: transform .2s var(--ease-out);
+}
+.cover-link:hover .cl-ext{ transform: translate(2px, -2px); }
 
 @media (max-width: 760px){
   .cover{ padding: clamp(64px, 12vh, 96px) clamp(20px, 6vw, 40px); }

--- a/app/src/styles/sections/definition.css
+++ b/app/src/styles/sections/definition.css
@@ -129,13 +129,13 @@
 }
 .vsch{
   margin: 0;
-  padding: clamp(16px, 1.8vw, 22px);
+  padding: clamp(20px, 2.2vw, 28px);
   background: var(--paper-2);
   border: 1px solid var(--rule);
   border-radius: var(--radius-card);
   display: flex;
   flex-direction: column;
-  gap: 14px;
+  gap: clamp(16px, 2vw, 22px);
 }
 .vsch-cap{
   font-family: var(--sans);
@@ -145,7 +145,12 @@
   color: var(--ink-3);
   font-weight: 600;
 }
-.vsch-svg{ width: 100%; height: auto; display: block; }
+.vsch-svg{
+  width: 100%;
+  height: auto;
+  display: block;
+  margin: 2px 0 4px;
+}
 .vsch-note{
   margin: 0;
   font-family: var(--display);

--- a/app/src/styles/sections/footer.css
+++ b/app/src/styles/sections/footer.css
@@ -25,6 +25,7 @@
   display: inline-flex;
   align-items: center;
   gap: 8px;
+  min-width: 44px;
   min-height: 44px;
   color: var(--ink-3);
   text-decoration: none;
@@ -64,5 +65,5 @@
     flex-direction: column;
     gap: 2px;
   }
-  .footer-link{ min-height: 40px; }
+  .footer-link{ min-height: 44px; }
 }

--- a/app/src/styles/sections/layout.css
+++ b/app/src/styles/sections/layout.css
@@ -47,7 +47,7 @@
 .si-nav{ display: flex; flex-direction: column; }
 .si-link{
   display: flex; align-items: baseline; gap: 10px;
-  min-height: 40px; padding: 9px 0 9px 12px; margin-left: -14px;
+  min-height: 44px; padding: 11px 0 11px 12px; margin-left: -14px;
   font-family: var(--sans); font-size: 14px;
   color: var(--ink-3); text-decoration: none;
   border-left: 2px solid transparent;
@@ -116,7 +116,7 @@
 .si-contact-links{ display: flex; gap: 8px; }
 .si-contact-link{
   display: inline-flex; align-items: center; justify-content: center;
-  width: 34px; height: 34px;
+  width: 44px; height: 44px;
   color: var(--ink-2);
   border: 1px solid var(--rule);
   border-radius: 8px;

--- a/app/src/styles/sections/principles.css
+++ b/app/src/styles/sections/principles.css
@@ -11,13 +11,15 @@
 
 /* ---- Row: number · statement · code panel, side by side ---- */
 .principle{
+  --row-inset: clamp(18px, 2.2vw, 28px);
   position: relative;
   display: grid;
-  grid-template-columns: clamp(48px, 5vw, 64px) minmax(0, 1fr) minmax(300px, 460px);
-  gap: clamp(20px, 3vw, 56px);
+  grid-template-columns: clamp(48px, 5vw, 64px) minmax(0, 1fr) minmax(280px, 420px);
+  gap: clamp(18px, 2vw, 28px);
   align-items: start;
+  min-width: 0;
   /* Generous breathing room — rows were too cramped. */
-  padding: clamp(40px, 6.5vh, 78px) 0;
+  padding: clamp(40px, 6.5vh, 78px) var(--row-inset);
   scroll-margin-top: clamp(20px, 8vh, 80px);
   border-bottom: 1px solid var(--rule);
   background: var(--paper);
@@ -31,7 +33,7 @@
 .principle::before{
   content: "";
   position: absolute;
-  inset: clamp(12px, 2vh, 22px) calc(-1 * clamp(14px, 1.6vw, 26px));
+  inset: clamp(12px, 2vh, 22px) 0;
   border-radius: var(--radius-card);
   border: 1px solid var(--accent-soft);
   background: var(--paper-2);
@@ -52,6 +54,8 @@
   grid-column: 3;
   margin-top: 4px;
   align-self: start;
+  min-width: 0;
+  max-width: 100%;
 }
 /* Number + statement live in the first two columns */
 .principle .p-num{ grid-column: 1; }
@@ -64,6 +68,11 @@
 
 /* ---- Number — a self-permalink (jumps to this principle's anchor) ---- */
 .p-num{
+  display: inline-flex;
+  align-items: flex-start;
+  justify-content: flex-start;
+  min-width: 44px;
+  min-height: 44px;
   font-family: var(--display);
   font-style: normal;
   font-weight: 700;
@@ -173,9 +182,10 @@
 /* ---- Mobile: number over statement, panel below ---- */
 @media (max-width: 560px){
   .principle{
+    --row-inset: clamp(18px, 5vw, 22px);
     grid-template-columns: 44px 1fr;
     gap: 14px;
-    padding: clamp(24px, 6vw, 36px) 0;
+    padding: clamp(24px, 6vw, 36px) var(--row-inset);
   }
   .p-num{ font-size: clamp(32px, 8vw, 44px); }
   .p-num .p-icon{

--- a/app/src/styles/sections/signature.css
+++ b/app/src/styles/sections/signature.css
@@ -88,7 +88,7 @@
 .sign-btn--sidebar{
   display: flex;
   width: 100%;
-  min-height: 0;
+  min-height: 44px;
   gap: 0;
   padding: 0;
   margin-top: clamp(10px, 1.8vh, 16px);
@@ -259,8 +259,9 @@
   list-style: none;
   margin: 0; padding: 0;
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(min(220px, 100%), 1fr));
   gap: clamp(10px, 1.4vw, 18px);
+  min-width: 0;
 }
 
 /* ---- Signature card — light panel, hairline border ---- */
@@ -269,27 +270,46 @@
   display: flex;
   flex-direction: column;
   gap: 10px;
+  min-width: 0;
+  max-width: 100%;
   padding: 14px 14px 14px 12px;
   background: var(--paper-2);
   border: 1px solid var(--rule);
   border-radius: var(--radius-card);
+  overflow: hidden;
   transition:
     transform var(--dur-short) var(--ease-out),
     box-shadow var(--dur-short) var(--ease-out),
     border-color var(--dur-short) var(--ease-out),
     background var(--dur-short) var(--ease-out);
 }
-.sig-card:hover{
+.sig-card::before{
+  content: "";
+  position: absolute;
+  inset: 0 12px auto;
+  height: 2px;
+  background: var(--accent);
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform var(--dur-med) var(--ease-out);
+}
+.sig-card:hover,
+.sig-card:focus-within{
   transform: translateY(-2px);
   background: var(--paper-3);
   border-color: var(--accent-soft);
   box-shadow: var(--shadow-card);
+}
+.sig-card:hover::before,
+.sig-card:focus-within::before{
+  transform: scaleX(1);
 }
 
 .sig-top{
   display: flex;
   align-items: center;
   gap: 12px;
+  min-width: 0;
 }
 
 .sig-link{
@@ -310,6 +330,16 @@
   background: var(--paper);
   border: 1px solid var(--rule);
   object-fit: cover;
+  transition:
+    transform var(--dur-med) var(--ease-out),
+    border-color var(--dur-med) var(--ease-out),
+    filter var(--dur-med) var(--ease-out);
+}
+.sig-card:hover .sig-avatar,
+.sig-card:focus-within .sig-avatar{
+  transform: scale(1.04);
+  border-color: oklch(from var(--accent) l c h / 0.42);
+  filter: saturate(1.08);
 }
 
 .sig-meta{
@@ -329,6 +359,11 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  transition: color var(--dur-short) var(--ease-out);
+}
+.sig-card:hover .sig-name,
+.sig-card:focus-within .sig-name{
+  color: var(--accent);
 }
 .sig-affil{
   font-family: var(--sans);
@@ -351,6 +386,7 @@
   line-height: 1.55;
   color: var(--ink-2);
   border-top: 1px solid var(--rule);
+  overflow-wrap: anywhere;
 }
 
 /* Date stamp */
@@ -362,25 +398,85 @@
   color: var(--ink-3);
 }
 
+.sig-card-foot{
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: auto;
+  min-width: 0;
+}
+.sig-entry{
+  display: inline-flex;
+  align-items: center;
+  min-height: 22px;
+  padding: 0 8px;
+  border: 1px solid var(--rule);
+  border-radius: var(--radius-input);
+  font-family: var(--sans);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  color: var(--ink-3);
+  background: var(--paper);
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+  transform: rotate(0deg);
+  transition:
+    transform var(--dur-med) var(--ease-out),
+    border-color var(--dur-med) var(--ease-out),
+    color var(--dur-med) var(--ease-out),
+    background var(--dur-med) var(--ease-out);
+}
+.sig-card:hover .sig-entry,
+.sig-card:focus-within .sig-entry{
+  transform: rotate(-2deg) translateY(-1px);
+  border-color: oklch(from var(--accent) l c h / 0.42);
+  color: var(--accent);
+  background: var(--accent-soft);
+}
+
 /* LinkedIn icon — subtle, no fill */
 .sig-linkedin{
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 30px; height: 30px;
+  width: 44px; height: 44px;
   border-radius: 6px;
   color: var(--ink-3);
   background: transparent;
   flex: none;
   transition:
     color var(--dur-short) var(--ease-out),
-    background var(--dur-short) var(--ease-out);
+    background var(--dur-short) var(--ease-out),
+    transform var(--dur-short) var(--ease-out);
 }
 .sig-linkedin:hover{
   color: var(--accent);
   background: var(--accent-soft);
+  transform: translateY(-1px);
 }
 .sig-linkedin svg{ width: 14px; height: 14px; }
+
+@media (prefers-reduced-motion: reduce){
+  .sig-card,
+  .sig-card::before,
+  .sig-avatar,
+  .sig-name,
+  .sig-entry,
+  .sig-linkedin{
+    transition: none;
+  }
+  .sig-card:hover,
+  .sig-card:focus-within,
+  .sig-card:hover .sig-avatar,
+  .sig-card:focus-within .sig-avatar,
+  .sig-card:hover .sig-entry,
+  .sig-card:focus-within .sig-entry,
+  .sig-linkedin:hover{
+    transform: none;
+  }
+}
 
 /* ---- Print ---- */
 @media print{
@@ -392,7 +488,7 @@
 /* ---- Mobile: stack signatories one under another (full-width cards) ---- */
 @media (max-width: 640px){
   .sig-grid{
-    grid-template-columns: 1fr;
+    grid-template-columns: minmax(0, 1fr);
   }
 }
 

--- a/app/src/styles/sections/signature.css
+++ b/app/src/styles/sections/signature.css
@@ -3,6 +3,149 @@
 .signature{
   padding: 0 0 clamp(56px, 9vh, 100px);
 }
+
+.signature-open{
+  min-height: clamp(300px, 34vh, 410px);
+  padding: clamp(52px, 8vh, 88px) 0 clamp(38px, 6vh, 62px);
+  isolation: isolate;
+  overflow: hidden;
+}
+.signature-open::before{
+  height: 3px;
+  background: var(--ink);
+}
+.signature-open::after{
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 1px;
+  background: var(--rule);
+}
+
+.signature-open-mark{
+  position: absolute;
+  right: clamp(-72px, -4vw, -28px);
+  top: 50%;
+  width: clamp(240px, 30vw, 390px);
+  height: clamp(240px, 30vw, 390px);
+  color: oklch(from var(--accent) l c h / 0.12);
+  transform: translateY(-50%) rotate(-8deg);
+  z-index: -1;
+  pointer-events: none;
+}
+.signature-open-mark line,
+.signature-open-mark circle{
+  transform-box: fill-box;
+  transform-origin: center;
+}
+.signature-open:hover .som-bar-small,
+.signature-open:hover .som-bar-big{
+  animation: signature-mark-draw .9s var(--ease-out) both;
+}
+.signature-open:hover .som-dot{
+  animation: signature-mark-pulse .9s var(--ease-out) both;
+}
+@keyframes signature-mark-draw{
+  from{ opacity: .35; transform: translateY(10px) scale(.96); }
+  to{ opacity: 1; transform: none; }
+}
+@keyframes signature-mark-pulse{
+  0%, 100%{ transform: scale(1); }
+  50%{ transform: scale(1.14); }
+}
+
+.signature-open-body{
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(124px, 174px);
+  gap: clamp(24px, 5vw, 72px);
+  align-items: end;
+  max-width: 100%;
+  z-index: 1;
+}
+.signature-open-copy{
+  min-width: 0;
+  max-width: 780px;
+}
+.signature-kicker{
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: clamp(18px, 2.5vh, 28px);
+  font-family: var(--sans);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: .18em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+.signature-kicker::before{
+  content: "";
+  width: clamp(56px, 8vw, 104px);
+  height: 2px;
+  background: var(--accent);
+}
+.signature-open .chapter-lede{
+  max-width: 720px;
+}
+.signature-open .chapter-lede p{
+  color: var(--ink);
+}
+
+.signature-seal{
+  position: relative;
+  display: grid;
+  justify-items: center;
+  align-content: center;
+  aspect-ratio: 1;
+  min-width: 0;
+  padding: clamp(16px, 2vw, 22px);
+  border: 2px solid oklch(from var(--ink) l c h / 0.22);
+  border-radius: 50%;
+  color: var(--ink);
+  background: oklch(from var(--paper) l c h / 0.72);
+  transform: rotate(-6deg);
+}
+.signature-seal::before,
+.signature-seal::after{
+  content: "";
+  position: absolute;
+  inset: 10px;
+  border: 1px solid oklch(from var(--accent) l c h / 0.34);
+  border-radius: 50%;
+  pointer-events: none;
+}
+.signature-seal::after{
+  inset: 18px;
+  border-color: var(--rule);
+}
+.signature-seal-label,
+.signature-seal-caption{
+  position: relative;
+  z-index: 1;
+  font-family: var(--sans);
+  font-size: clamp(9px, .9vw, 11px);
+  font-weight: 700;
+  letter-spacing: .16em;
+  line-height: 1.2;
+  text-transform: uppercase;
+  color: var(--ink-3);
+  text-align: center;
+}
+.signature-seal strong{
+  position: relative;
+  z-index: 1;
+  font-family: var(--display);
+  font-size: clamp(44px, 6vw, 76px);
+  font-weight: 800;
+  line-height: .9;
+  letter-spacing: -0.035em;
+  color: var(--accent);
+  font-variant-numeric: tabular-nums;
+}
+
 /* Contribute links under the CTA — organisation, then repository. */
 .sign-contribute{
   margin-top: 14px;
@@ -173,6 +316,11 @@
   animation: logo-draw 0.8s var(--ease-out) both;
 }
 @media (prefers-reduced-motion: reduce){
+  .signature-open:hover .som-bar-small,
+  .signature-open:hover .som-bar-big,
+  .signature-open:hover .som-dot{
+    animation: none;
+  }
   .sign-logo .sl-bar-small,
   .sign-logo .sl-bar-big{ animation: none; stroke-dashoffset: 0; }
   .sign-logo .sl-dot{ animation: none; }
@@ -487,6 +635,37 @@
 
 /* ---- Mobile: stack signatories one under another (full-width cards) ---- */
 @media (max-width: 640px){
+  .signature-open{
+    min-height: 0;
+    padding: clamp(56px, 9vh, 80px) 0 clamp(36px, 7vh, 56px);
+  }
+  .signature-open-mark{
+    right: -126px;
+    top: auto;
+    bottom: -132px;
+    width: 310px;
+    height: 310px;
+    transform: rotate(-8deg);
+    color: oklch(from var(--accent) l c h / 0.09);
+  }
+  .signature-open-body{
+    grid-template-columns: minmax(0, 1fr);
+    gap: 26px;
+  }
+  .signature-kicker{
+    margin-bottom: 18px;
+    font-size: 10px;
+    letter-spacing: .14em;
+  }
+  .signature-kicker::before{ width: 52px; }
+  .signature-seal{
+    justify-self: start;
+    width: 128px;
+    transform: rotate(-4deg);
+  }
+  .signature-seal strong{
+    font-size: 44px;
+  }
   .sig-grid{
     grid-template-columns: minmax(0, 1fr);
   }

--- a/app/src/styles/sections/terminal.css
+++ b/app/src/styles/sections/terminal.css
@@ -20,8 +20,10 @@
   min-width: 0;
   max-width: 100%;
   box-shadow:
+    0 0 0 10px oklch(1 0 0 / 0.58),
     0 0 0 1px oklch(0.28 0.06 272),
-    0 12px 32px -20px oklch(0.10 0.08 268 / 0.45);
+    0 0 38px -10px oklch(1 0 0 / 0.95),
+    0 18px 42px -24px oklch(0.10 0.08 268 / 0.48);
 }
 
 /* No traffic-light tbar */

--- a/app/src/styles/sections/terminal.css
+++ b/app/src/styles/sections/terminal.css
@@ -17,6 +17,8 @@
   line-height: 1.65;
   overflow: hidden;
   position: relative;
+  min-width: 0;
+  max-width: 100%;
   box-shadow:
     0 0 0 1px oklch(0.28 0.06 272),
     0 12px 32px -20px oklch(0.10 0.08 268 / 0.45);
@@ -65,6 +67,7 @@
   padding: clamp(10px, 1.4vw, 14px) clamp(18px, 2.2vw, 24px) clamp(16px, 2vw, 20px);
   position: relative;
   z-index: 2;
+  overflow-x: auto;
 }
 
 /* ---- Line reveal animation ---- */

--- a/app/src/styles/sections/value-art.css
+++ b/app/src/styles/sections/value-art.css
@@ -12,6 +12,8 @@
   align-self: stretch;
   position: relative;
   overflow: hidden;
+  min-width: 0;
+  max-width: 100%;
   /* Hairline outline only — no heavy shadow */
   box-shadow: 0 0 0 1px oklch(0.181 0.117 266 / 0.6);
 }
@@ -47,6 +49,8 @@
   position: relative;
   z-index: 1;
   min-height: clamp(260px, 32vh, 340px);
+  min-width: 0;
+  max-width: 100%;
 }
 
 /* ---- Column layout ---- */
@@ -95,6 +99,7 @@
   font-family: var(--mono);
   white-space: pre;
   overflow-x: auto;
+  max-width: 100%;
   margin: 0;
   font-size: inherit;
   line-height: inherit;
@@ -157,6 +162,7 @@
   margin: 0;
   white-space: pre;
   overflow-x: auto;
+  max-width: 100%;
   color: inherit;
   font-family: var(--mono);
   font-size: inherit;

--- a/app/src/styles/sections/value-art.css
+++ b/app/src/styles/sections/value-art.css
@@ -15,7 +15,11 @@
   min-width: 0;
   max-width: 100%;
   /* Hairline outline only — no heavy shadow */
-  box-shadow: 0 0 0 1px oklch(0.181 0.117 266 / 0.6);
+  box-shadow:
+    0 0 0 10px oklch(1 0 0 / 0.58),
+    0 0 0 1px oklch(0.181 0.117 266 / 0.6),
+    0 0 42px -10px oklch(1 0 0 / 0.95),
+    0 18px 42px -24px oklch(from var(--ink) l c h / 0.42);
 }
 
 /* CRT scanline overlay — kept but dialled back on a light doc */

--- a/app/src/styles/sections/values.css
+++ b/app/src/styles/sections/values.css
@@ -8,15 +8,17 @@
 .plate{
   display: grid;
   gap: 0;
-  padding: clamp(20px, 4vh, 40px) 0 clamp(40px, 7vh, 72px);
+  padding: clamp(12px, 2.5vh, 28px) 0 clamp(40px, 7vh, 72px);
 }
 .plate-row{
+  --row-inset: clamp(18px, 2.2vw, 28px);
   display: grid;
-  grid-template-columns: clamp(70px, 8vw, 120px) 1fr;
-  gap: clamp(14px, 2vh, 22px) clamp(32px, 5vw, 72px);
+  grid-template-columns: clamp(56px, 6vw, 92px) minmax(0, 1fr);
+  gap: clamp(14px, 2vh, 22px) clamp(28px, 4vw, 52px);
   align-items: start;
   position: relative;
-  padding: clamp(44px, 7vh, 80px) 0 clamp(40px, 6vh, 64px);
+  min-width: 0;
+  padding: clamp(44px, 7vh, 80px) var(--row-inset) clamp(40px, 6vh, 64px);
   scroll-margin-top: clamp(20px, 8vh, 80px);
 }
 /* Spotlight highlight — soft card panel fades + lifts in when the row is centred
@@ -26,7 +28,7 @@
   display: block;
   content: "";
   position: absolute;
-  inset: clamp(16px, 2vh, 26px) calc(-1 * clamp(14px, 1.6vw, 26px));
+  inset: clamp(16px, 2vh, 26px) 0;
   border-radius: var(--radius-card);
   border: 1px solid var(--accent-soft);
   background: var(--paper-2);
@@ -44,13 +46,15 @@
 .plate-row .pr-art{
   grid-column: 1 / -1;
   margin-top: clamp(18px, 3vh, 32px);
+  min-width: 0;
+  max-width: 100%;
 }
 
 /* Hairline rule above each row — clean, no ornament */
 .plate-row::before{
   content: "";
   position: absolute;
-  top: 0; left: 0; right: 0;
+  top: 0; left: var(--row-inset); right: var(--row-inset);
   height: 1px;
   background: var(--rule);
   pointer-events: none;
@@ -63,7 +67,7 @@
 .plate-row .pr-icon{
   position: absolute;
   top: clamp(20px, 4vh, 42px);
-  right: 0;
+  right: var(--row-inset);
   width: clamp(60px, 5.8vw, 80px);
   height: clamp(60px, 5.8vw, 80px);
   padding: clamp(15px, 1.5vw, 21px);
@@ -75,18 +79,22 @@
 
 /* ---- Folio numeral — a self-permalink (ghost by default, lifts on hover) ---- */
 .pr-folio{
-  display: block;
-  width: fit-content;
+  display: inline-flex;
+  align-items: flex-start;
+  justify-content: flex-end;
+  width: 100%;
+  min-width: 44px;
+  min-height: 44px;
   font-family: var(--display);
   font-weight: 800;
   font-style: normal;                    /* no italic — design rule */
-  font-size: clamp(52px, 7vw, 104px);
+  font-size: clamp(48px, 6.3vw, 86px);
   line-height: 0.82;
   color: var(--ink);
-  opacity: 0.10;                         /* ghost numeral — structural, not decorative */
+  opacity: 0.14;                         /* ghost numeral — structural, not decorative */
   align-self: start;
   padding-top: clamp(6px, 1vh, 14px);
-  letter-spacing: -0.05em;
+  letter-spacing: -0.035em;
   user-select: none;
   text-decoration: none;
   cursor: pointer;
@@ -217,20 +225,40 @@
 /* ---- Mobile: single column ---- */
 @media (max-width: 820px){
   .plate-row{
-    grid-template-columns: 1fr;
-    gap: clamp(18px, 2.5vh, 28px);
-    padding: clamp(36px, 6vh, 52px) 0 clamp(24px, 4vh, 36px);
+    --row-inset: clamp(18px, 5vw, 22px);
+    grid-template-columns: clamp(34px, 10vw, 46px) minmax(0, 1fr);
+    gap: clamp(12px, 3vw, 18px);
+    padding: clamp(30px, 6vh, 46px) var(--row-inset) clamp(28px, 5vh, 42px);
+  }
+  .plate-row::before{
+    left: var(--row-inset);
+    right: var(--row-inset);
   }
   .pr-folio{
-    font-size: clamp(40px, 10vw, 60px);
-    padding-top: 0;
-    line-height: 0.9;
+    justify-content: flex-start;
+    width: 44px;
+    font-size: clamp(30px, 8.5vw, 40px);
+    line-height: 0.88;
+    padding-top: 5px;
+  }
+  .pr-text{
+    grid-column: 2;
+    min-width: 0;
+  }
+  .plate-row .pr-art{
+    grid-column: 1 / -1;
+    margin-top: clamp(12px, 2.5vh, 22px);
   }
   .pr-text .left{
-    font-size: clamp(32px, 8vw, 48px);
+    font-size: clamp(32px, 8.2vw, 46px);
+    line-height: 0.94;
+  }
+  .pr-text .over{
+    margin-top: 2px;
   }
   .plate-row .pr-icon{
-    top: clamp(0px, 1vh, 6px);
+    top: clamp(16px, 4vw, 22px);
+    right: var(--row-inset);
     width: clamp(50px, 13vw, 60px);
     height: clamp(50px, 13vw, 60px);
     padding: clamp(12px, 3.2vw, 15px);

--- a/app/src/styles/tokens.css
+++ b/app/src/styles/tokens.css
@@ -49,7 +49,7 @@
      one colour moment. Derived from --accent / --ink so they track the tweaks. */
   --shadow-cta: 0 1px 0 0 oklch(1 0 0 / 0.12) inset, 0 8px 24px -8px oklch(from var(--accent) l c h / 0.45);
   --shadow-cta-hover: 0 1px 0 0 oklch(1 0 0 / 0.15) inset, 0 14px 32px -8px oklch(from var(--accent) l c h / 0.55);
-  --shadow-card: 0 12px 32px -18px oklch(from var(--ink) l c h / 0.22);
+  --shadow-card: 0 6px 8px -7px oklch(from var(--ink) l c h / 0.24);
   --shadow-modal: 0 24px 64px -24px oklch(from var(--ink) l c h / 0.45);
   --scrim: oklch(from var(--ink) l c h / 0.45);
 }


### PR DESCRIPTION
## Summary
- Add a public-facing signature registry surface and update the signature section to present entries more clearly
- Refresh the cover, values, principles, terminal, footer, and layout styles for a more cohesive manifesto presentation
- Update supporting definition/spec components and tokens to match the new visual system

## Testing
- Not run (not requested)
- Changes were validated through the existing app structure and section-level updates