### PR TITLE
sign: François Delbrayelle

### DIFF
--- a/app/src/content/signatories/fdelbrayelle.yml
+++ b/app/src/content/signatories/fdelbrayelle.yml
@@ -1,0 +1,8 @@
+github: fdelbrayelle
+name: François Delbrayelle
+linkedin: https://www.linkedin.com/in/fdelbrayelle
+affiliation: Kestra
+statement: >
+  Context Engineering taught me that AI doesn't need better prompts — it needs
+  the right context. At Kestra, we automated our full plugin SDLC by encoding
+  our engineering knowledge into agents, not by bypassing it.


### PR DESCRIPTION
Signing the manifesto as a practitioner of AI-driven development.

## Signatory

- **GitHub**: fdelbrayelle
- **Name**: François Delbrayelle
- **LinkedIn**: https://www.linkedin.com/in/fdelbrayelle
- **Affiliation**: Kestra

## Statement

> Context Engineering taught me that AI doesn't need better prompts — it needs the right context. At Kestra, we automated our full plugin SDLC by encoding our engineering knowledge into agents, not by bypassing it.

Related article: [Context Engineering in Practice: Automating the Plugin SDLC at Kestra](https://medium.com/kestra-engineering/context-engineering-in-practice-automating-the-plugin-sdlc-at-kestra-43c7724ba44b)