### PR TITLE
Smooth out the sign flow: fork expectation + drop obsolete signed_on

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,8 +28,10 @@ Required fields:
 ```yaml
 github: your-handle
 name: Your Name
-signed_on: YYYY-MM-DD
 ```
+
+The signature date is derived from the git commit that adds your file, so
+there is no `signed_on` field.
 
 See [SIGNATORIES.md](./SIGNATORIES.md) for the full guide.
 

--- a/SIGNATORIES.md
+++ b/SIGNATORIES.md
@@ -10,7 +10,7 @@ request.
 Go to **[ai-driven-development.org](https://ai-driven-development.org)** and
 click **Sign the manifesto**. It opens GitHub's web editor with the file
 already pre-filled — same link as
-[this one](https://github.com/ai-driven-dev/manifest/new/main/app/src/content/signatories?filename=YOUR-HANDLE.yml&value=github%3A%20your-handle%0Aname%3A%20Your%20Full%20Name%0Alinkedin%3A%20%23%20optional%20-%20https%3A%2F%2Fwww.linkedin.com%2Fin%2F...%0Aaffiliation%3A%20%23%20optional%20-%20title%20or%20company%0Asigned_on%3A%202026-05-08%0Astatement%3A%20%23%20optional%20-%20one-line%20public%20statement%20%28max%20280%20chars%29%0A).
+[this one](https://github.com/ai-driven-dev/manifest/new/main/app/src/content/signatories?filename=YOUR-HANDLE.yml&value=github%3A%20your-handle%0Aname%3A%20Your%20Full%20Name%0Alinkedin%3A%20%23%20optional%20-%20https%3A%2F%2Fwww.linkedin.com%2Fin%2F...%0Aaffiliation%3A%20%23%20optional%20-%20title%20or%20company%0Astatement%3A%20%23%20optional%20-%20one-line%20public%20statement%20%28max%20280%20chars%29%0A).
 
 This flow is for **everyone — Core Team members included**. Nobody has push
 access to this repository; GitHub forks it for you automatically.
@@ -22,8 +22,8 @@ What happens:
    and the YAML body filled in.
 3. Replace the filename's `YOUR-HANDLE` with your **actual GitHub handle**
    (lowercase letters, digits, hyphens — same as in your profile URL).
-4. Replace the placeholder values in the file body. Set `signed_on` to
-   today's date.
+4. Replace the placeholder values in the file body. There is no date field —
+   your signature date is derived from the commit that lands on `main`.
 5. Click **Propose new file**. GitHub opens a pull request automatically.
 
 A maintainer reviews and merges. Your name appears on
@@ -60,8 +60,9 @@ gh pr create --fill
 ## File format
 
 See [`app/src/content/signatories/_SCHEMA.md`](./app/src/content/signatories/_SCHEMA.md)
-for the canonical reference. Required fields: `github`, `name`,
-`signed_on`. Optional: `linkedin`, `affiliation`, `statement`.
+for the canonical reference. Required fields: `github`, `name`. Optional:
+`linkedin`, `affiliation`, `statement`. There is no `signed_on` field — the
+signature date is derived from the git commit that adds your file.
 
 The build validates every file against a Zod schema. A malformed YAML
 makes the CI red — review before merge catches it either way.

--- a/app/src/components/sections/Signature.astro
+++ b/app/src/components/sections/Signature.astro
@@ -40,6 +40,12 @@ const registryCount = String(count).padStart(3, '0');
 
   <div class="sign-cta reveal">
     <SignButton />
+    <p class="sign-cta-note">
+      Signing happens on GitHub. Nobody has push access here — not even the core
+      team — so GitHub first asks you to <strong>fork the repo</strong>. That is
+      one click and expected; the pre-filled file then opens on your fork, ready
+      to edit. <a href="https://github.com/ai-driven-dev/manifest/blob/main/SIGNATORIES.md">Full signing guide</a>.
+    </p>
   </div>
 
   <SignatureWall />

--- a/app/src/content/signatories/amandinemiceli.yml
+++ b/app/src/content/signatories/amandinemiceli.yml
@@ -2,5 +2,4 @@ github: amandinemiceli
 name: Amandine Miceli-Boucher
 linkedin: https://www.linkedin.com/in/amandinemiceli/
 affiliation: AI Driven-Dev
-signed_on: 2026-06-10
 statement: Perseverance is the mother of success, AI lights my way there.

--- a/app/src/content/signatories/bouziane-hamzi.yml
+++ b/app/src/content/signatories/bouziane-hamzi.yml
@@ -3,4 +3,3 @@ name: Bouziane HAMZI
 linkedin: https://www.linkedin.com/in/bhamzi
 affiliation: STOWA DEVELOPMENT
 statement: AI-Driven Development, the method that lets me move faster with AI while keeping quality, understanding, and ownership under control.
-signed_on: 2026-06-04

--- a/app/src/content/signatories/cduverne.yml
+++ b/app/src/content/signatories/cduverne.yml
@@ -2,5 +2,4 @@ github: cduverne
 name: Cyrille Duverne
 linkedin: https://www.linkedin.com/in/cyrilleduverne/
 affiliation: Senior Enterprise Architect
-signed_on: 2026-06-19
 statement: AI is the new cloud...

--- a/app/src/content/signatories/nicolasdaudin.yml
+++ b/app/src/content/signatories/nicolasdaudin.yml
@@ -2,5 +2,4 @@ github: nicolasdaudin
 name: Nicolas Daudin
 linkedin: https://www.linkedin.com/in/nicolasdaudin/
 affiliation: AI-Driven Dev
-signed_on: 2026-06-12
 statement: AI is reshaping how we write code. I'm here to do it thoughtfully, and help others navigate that shift.

--- a/app/src/content/signatories/promathieuthiry.yml
+++ b/app/src/content/signatories/promathieuthiry.yml
@@ -2,6 +2,5 @@ github: promathieuthiry
 name: Mathieu Thiry
 linkedin: https://www.linkedin.com/in/mathieu-thiry/
 affiliation: TeneX Studio - Frontend Engineer
-signed_on: 2026-06-07
 statement: >
   I use AI to move faster, but I keep the hard parts human: intent, taste, judgment, and accountability.

--- a/app/src/content/signatories/tidusia.yml
+++ b/app/src/content/signatories/tidusia.yml
@@ -2,5 +2,4 @@ github: tidusia
 name: Thibaud Duthoit
 linkedin: https://www.linkedin.com/in/thibaudduthoit/
 affiliation: AI-Driven Dev
-signed_on: 2026-05-08
 statement: AIDD dev crafter


### PR DESCRIPTION
## Other change

Two frictions reported by signers on the sign flow, both fixed here.

### 1. "You need to fork this repository" reads as a broken flow

Clicking **Sign** sends signers to GitHub's `/new/...` editor. Since nobody has push access to this repo (core team included), GitHub shows a *"You need to fork this repository"* interstitial instead of the pre-filled editor. Several people read this as the button being broken — they don't realize the fork is one expected click, after which the pre-filled file opens on their fork.

Fix: surface that expectation right under the button. Reuses the already-styled-but-unused `.sign-cta-note` class — no new CSS — to say the fork prompt is normal and link the full signing guide.

### 2. Obsolete `signed_on` field still in the guides and some YAML

`signed_on` was removed from the data model: the signature date is derived from the git commit that adds each file (`app/scripts/gen-signature-dates.mjs`), and the Zod schema in `app/src/content.config.ts` has no such field. `_SCHEMA.md` documents this, but three places drifted:

- **`SIGNATORIES.md`** — remove `signed_on: 2026-05-08` from the prefill link (now identical to the live `SignButton.astro` template), drop the "Set `signed_on`" step, fix "File format" to require only `github` + `name`.
- **`CONTRIBUTING.md`** — remove `signed_on: YYYY-MM-DD` from the required-fields snippet.
- **6 signatory `.yml` files** — strip the leftover `signed_on` line (Zod already ignored it, so no behavior change; stops it being copied as an example).

Removing `signed_on` from YAML does **not** change any displayed date — the date comes from the commit that first added the file (`git log --diff-filter=A`), not the file contents.

### Not addressed here (GitHub-side, out of our control)

The reporter also saw a `422` and a `503 collector.github.com/github/collect` in the browser console. Those come from GitHub's own `/new/...` page (telemetry beacon + fork pre-check), not this repo — the prefill link is valid (anonymous request returns `200`) and the errors don't block the "Propose new file" commit. No code change here can fix them.

### Verification

- `npm run build` passes; `check-component-loc.sh` PASS (Signature.astro 54 LOC).
- `grep` confirms no stray `signed_on` outside the explanatory notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M6gysPekV6RbhbcXvycV9L