### PR TITLE
fix(signature): trigger the signature workflow on the form label only

### DIFF
--- a/.github/workflows/signature-pr.yml
+++ b/.github/workflows/signature-pr.yml
@@ -15,7 +15,10 @@ concurrency:
 
 jobs:
   create-signature-pr:
-    if: github.event.issue.state == 'open' && (contains(github.event.issue.labels.*.name, 'signature-request') || (startsWith(github.event.issue.title, 'Signature:') && contains(github.event.issue.body, '### Display name')))
+    # The label is applied server-side by the Issue Form and cannot be set by a
+    # contributor without triage rights. Title and body can, so they are not a
+    # trigger. Delete the label and this workflow stops firing.
+    if: github.event.issue.state == 'open' && contains(github.event.issue.labels.*.name, 'signature-request')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Why

`create-signature-pr` fired on either the `signature-request` label **or** a title starting with `Signature:` plus `### Display name` in the body.

Title and body are contributor-controlled. `blank_issues_enabled: false` only hides the blank-issue link in the UI — `POST /repos/.../issues` still accepts an arbitrary title and body without going through the Issue Form. So the fallback let any user spawn a branch, a pull request, and an Actions run.

The label is the opposite: the Issue Form applies it server-side at creation, and a contributor without triage rights cannot add or remove one.

Scope of the old exposure, for the record: the signer handle comes from `issue.user.login`, not the body, and the path is `signatories/<handle>.yml` with a regex-validated handle. Nobody could sign as someone else or escape the directory. The cost was spam — branches, PRs, and Actions minutes.

## What

- Trigger on the label alone. No title or body fallback.
- Created the four labels the workflow and the form reference, none of which existed: `signature-request`, `signature-duplicate`, `signature-needs-fix`, `signature-pr-created`.

Missing labels are why issue #58 fired through the title branch, and why `gh issue edit --add-label signature-duplicate` logged `not found` (swallowed by `|| true`).

Without the labels the job never runs. Fails closed.

## Verified

Issue #58 run [29085276369](https://github.com/ai-driven-dev/manifest/actions/runs/29085276369): form → workflow → parse → duplicate guard, all green. Stopped at the duplicate guard because `blafourcade.yml` is already on `main`.

The rest of the path — write, commit, pull request, close — was then run end to end in a throwaway private repo carrying this branch's workflow, the same script, the same form, and the same Actions permissions, where the signer handle had no existing YAML:

- Issue opened with the `signature-request` label → `Signature PR` run succeeded.
- Branch `signature/blafourcade-1` pushed, PR `Add signature: Baptiste Lafourcade` opened by `app/github-actions`.
- Generated YAML is valid and complete; optional fields quoted.
- Issue commented with the PR URL, labelled `signature-pr-created`, closed as completed.

The label-only trigger fired correctly there. It is the mechanism this PR ships.

## Known blocker, measured

The generated PR cannot merge under the `main` ruleset today.

`gh pr create` runs with `GH_TOKEN: ${{ github.token }}`. In the sandbox the resulting `pull_request` event **did** create a `Validate` run, but it landed on `conclusion: action_required` — held for manual approval because the triggering actor is `github-actions[bot]`. `gh pr checks` reported `no checks reported on the branch`, and the PR sat on `mergeStateStatus: UNSTABLE`.

So `build` never reports on its own. On `main`, where `build` is a required status check, every signature PR would stall until a maintainer opens the Actions tab and clicks *Approve and run*. That is a click per signature, which defeats the automation.

Fixing it means giving `gh pr create` an identity that is not `GITHUB_TOKEN` — a GitHub App installation token via `actions/create-github-app-token`, or a fine-grained PAT in a secret. That is a separate PR; this one is the trigger hardening.