### PR TITLE
fix(signature): open the signature pull request as the bot App

### DIFF
--- a/.github/workflows/signature-pr.yml
+++ b/.github/workflows/signature-pr.yml
@@ -4,10 +4,10 @@ on:
   issues:
     types: [opened]
 
+# The job acts as the signature bot App, not as GITHUB_TOKEN, so the workflow
+# token itself needs nothing beyond reading the checked-out ref.
 permissions:
-  contents: write
-  issues: write
-  pull-requests: write
+  contents: read
 
 concurrency:
   group: signature-pr-${{ github.event.issue.number }}
@@ -21,7 +21,19 @@ jobs:
     if: github.event.issue.state == 'open' && contains(github.event.issue.labels.*.name, 'signature-request')
     runs-on: ubuntu-latest
     steps:
+      # A pull request opened by GITHUB_TOKEN leaves its Validate run stuck on
+      # action_required, so the required `build` check never reports and the
+      # signature PR can never merge. An App installation token is a distinct
+      # actor, so the run starts on its own.
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          app-id: ${{ vars.SIGNATURE_BOT_APP_ID }}
+          private-key: ${{ secrets.SIGNATURE_BOT_PRIVATE_KEY }}
+
       - uses: actions/checkout@v6
+        with:
+          token: ${{ steps.app-token.outputs.token }}
 
       - uses: actions/setup-node@v6
         with:
@@ -37,7 +49,7 @@ jobs:
       - name: Report invalid signature request
         if: steps.request.outcome == 'failure'
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
         run: |
           gh issue comment "$ISSUE_NUMBER" --body "Signature request could not be processed. Please check the form fields and submit again."
@@ -48,7 +60,7 @@ jobs:
         id: duplicate
         if: steps.request.outcome == 'success'
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           GITHUB_HANDLE: ${{ steps.request.outputs.github }}
           ISSUE_NUMBER: ${{ steps.request.outputs.issue_number }}
           SIGNATURE_PATH: ${{ steps.request.outputs.path }}
@@ -67,7 +79,7 @@ jobs:
         if: steps.duplicate.outputs.found == 'false'
         env:
           BRANCH: ${{ steps.request.outputs.branch }}
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           ISSUE_NUMBER: ${{ steps.request.outputs.issue_number }}
         run: |
           pr_url="$(gh pr list --head "$BRANCH" --state open --json url --jq '.[0].url // ""')"
@@ -116,7 +128,7 @@ jobs:
         env:
           BRANCH: ${{ steps.request.outputs.branch }}
           DISPLAY_NAME: ${{ steps.request.outputs.name }}
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           GITHUB_HANDLE: ${{ steps.request.outputs.github }}
         run: |
           pr_url="$(gh pr create \
@@ -129,7 +141,7 @@ jobs:
       - name: Close signature issue
         if: steps.pull-request.outputs.url != ''
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           ISSUE_NUMBER: ${{ steps.request.outputs.issue_number }}
           PR_URL: ${{ steps.pull-request.outputs.url }}
         run: |


### PR DESCRIPTION
## Why

The signature workflow opened its pull request with `GH_TOKEN: ${{ github.token }}`.

That pull request cannot merge under the `main` ruleset. Measured in a throwaway repo carrying this exact workflow, the same script, the same form, and the same Actions permissions:

| Pull request opened by | `Validate` run | `gh pr checks` | `mergeStateStatus` |
|---|---|---|---|
| `app/github-actions` (GITHUB_TOKEN) | `action_required` | no checks reported | `UNSTABLE` |
| `app/aidd-signature-bot` (App token) | `success` | `build` SUCCESS | `CLEAN` |

A run *is* created for the GITHUB_TOKEN pull request — my earlier claim that none was, on #59, was wrong. It is created and then held for manual approval, because the triggering actor is `github-actions[bot]`. The required `build` check never reports on its own, so every signature pull request would stall until a maintainer opens the Actions tab and clicks *Approve and run*. One click per signature.

## What

- Mint an installation token for the `aidd-signature-bot` GitHub App with `actions/create-github-app-token@v3`.
- Use it to check out, push the signature branch, and drive every `gh` call. The App is a distinct actor, so `Validate` starts on its own.
- Drop the job's own `permissions` to `contents: read`. It no longer writes anything as `GITHUB_TOKEN`.

The commit author stays `github-actions[bot]`. Committer identity does not affect what starts a workflow run; the pushing token does.

## Setup, already applied

- App `aidd-signature-bot` (id `4263893`), installed on this repository, scoped to `contents:write`, `issues:write`, `pull_requests:write`, `metadata:read`. Nothing more.
- Repository variable `SIGNATURE_BOT_APP_ID`, repository secret `SIGNATURE_BOT_PRIVATE_KEY`.

The App is deliberately **not** in the `main` ruleset `bypass_actors`. It can push a signature branch and open a pull request; it cannot write to `main`.

## Verified

Two issues opened through the form in the sandbox, before and after this change. The second produced pull request `Add signature: Baptiste Lafourcade` authored by `app/aidd-signature-bot`, with `build` green, `CLEAN`, and mergeable with no manual step. Generated YAML valid, issue commented, labelled `signature-pr-created`, and closed as completed.

Merging this makes the Issue Form flow end-to-end on `main`. The site CTA still points at the old pre-filled web editor and is unchanged by this PR.