### PR TITLE
feat(signature): point the sign CTA at the Issue Form

### DIFF
--- a/app/src/components/signature/SignButton.astro
+++ b/app/src/components/signature/SignButton.astro
@@ -1,20 +1,14 @@
 ---
-// CTA that opens GitHub's web editor pre-filled with a YAML signatory file.
-// No JS, no backend — just an anchor to GitHub's `/new/...?filename=...&value=...`
-// endpoint, which lets contributors propose a new file directly from the browser.
+// CTA that opens the signature Issue Form. Actions turns the submitted issue
+// into a reviewed pull request. The signer's handle is read from the issue
+// author, never from a field, so nobody can sign in someone else's name.
+//
+// No query params: the page is static and knows nothing about the visitor. The
+// form carries its own placeholders, which are hints rather than submitted text.
 
 const REPO = 'ai-driven-dev/manifest';
-const TARGET_PATH = 'app/src/content/signatories';
 
-const TEMPLATE = `github: your-handle
-name: Your Full Name
-linkedin: # optional - https://www.linkedin.com/in/...
-affiliation: # optional - title or company
-statement: # optional - one-line public statement (max 280 chars)
-`;
-
-const HREF = `https://github.com/${REPO}/new/main/${TARGET_PATH}?filename=YOUR-HANDLE.yml&value=${encodeURIComponent(TEMPLATE)}`;
-const GITHUB_URL = HREF;
+const GITHUB_URL = `https://github.com/${REPO}/issues/new?template=signature.yml`;
 
 interface Props {
   /** 'github' (default, bottom CTA) or 'aidd' (animated brand mark, sidebar). */

--- a/app/src/lib/site.ts
+++ b/app/src/lib/site.ts
@@ -8,8 +8,7 @@ export const SITE = {
   description:
     'Four values and twelve principles for developers who build software with AI as a deliberate partner.',
   repoUrl: 'https://github.com/ai-driven-dev/manifest',
-  signUrl:
-    'https://github.com/ai-driven-dev/manifest/new/main/app/src/content/signatories',
+  signUrl: 'https://github.com/ai-driven-dev/manifest/issues/new?template=signature.yml',
   publishedDate: '2026-05-08',
   modifiedDate: '2026-05-31',
   indexNowKey: 'a1f401c8d1e64cb99fbe0d7f4a462026',


### PR DESCRIPTION
## What

`SignButton.astro` opened GitHub's web editor pre-filled with a YAML signatory file:

```
/new/main/app/src/content/signatories?filename=YOUR-HANDLE.yml&value=<template>
```

It now opens the Issue Form:

```
/issues/new?template=signature.yml
```

Everything downstream already runs on `main`: the label-only trigger (#59) and the bot App that opens the pull request so `build` reports (#60).

## Why no prefilled fields

GitHub Issue Forms accept query params keyed by field `id`, so `?display_name=…` is possible. It is not useful here, and one variant of it is harmful.

The page is static and unauthenticated. It knows nothing about the visitor, so it has nothing true to put in a field.

And a prefilled `value` is submitted text, not a hint. `Your Full Name` is a one-line string under 120 characters, so the validator accepts it and it lands on the signature wall. The form's `placeholder` attributes already carry the guidance, greyed out and never submitted.

The one field worth prefilling — the GitHub handle — is gone from the form entirely. The workflow reads it from `issue.user.login`, which is why nobody can sign in someone else's name.

## Note

`SITE.signUrl` in `app/src/lib/site.ts` is read by nothing. Updated rather than left pointing at the retired flow. Worth deleting in a follow-up.

## Verified

`npm run build` clean, 52 unit tests pass, and the served production build renders:

```
data-github-url="https://github.com/ai-driven-dev/manifest/issues/new?template=signature.yml"
```

Merging this activates the new signing flow for visitors.