### PR TITLE
fix(signature): close every terminal signature issue and match an open PR by handle

### DIFF
--- a/.github/scripts/read-signature-request.js
+++ b/.github/scripts/read-signature-request.js
@@ -67,7 +67,9 @@ function checkLength(value, field) {
 
 function requiredText(value, field) {
   const text = clean(value);
-  if (!text) throw new Error(`${field} is required`);
+  // GitHub renders an unanswered field as `_No response_`, a non-empty string.
+  // A required field must reject it, or the signer is named `_No response_`.
+  if (!text || text === NO_RESPONSE) throw new Error(`${field} is required`);
   return checkLength(checkOneLine(text, field), field);
 }
 

--- a/.github/scripts/read-signature-request.test.js
+++ b/.github/scripts/read-signature-request.test.js
@@ -134,6 +134,15 @@ describe('signature request reader behavior', () => {
     assert.equal(outputs.statement_yaml, '"I review: plan, code, tests."');
   });
 
+  it('fails a signer issue when the required display name was left unanswered', () => {
+    const result = failRequestReader(signatureIssueEvent({
+      body: issueFormBody({ 'Display name': '_No response_' }),
+    }));
+
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /name is required/);
+  });
+
   it('fails a signer issue when the LinkedIn field cannot become a public URL', () => {
     const result = failRequestReader(signatureIssueEvent({
       body: issueFormBody({ 'LinkedIn profile': 'not-a-url' }),

--- a/.github/workflows/signature-pr.yml
+++ b/.github/workflows/signature-pr.yml
@@ -52,8 +52,9 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
         run: |
-          gh issue comment "$ISSUE_NUMBER" --body "Signature request could not be processed. Please check the form fields and submit again."
+          gh issue comment "$ISSUE_NUMBER" --body "Signature request could not be processed. Check the form fields and open a new request: editing this issue does not re-run the workflow, which only reacts to newly opened issues."
           gh issue edit "$ISSUE_NUMBER" --add-label "signature-needs-fix" || true
+          gh issue close "$ISSUE_NUMBER" --reason "not planned"
           exit 1
 
       - name: Stop duplicate signature
@@ -72,21 +73,29 @@ jobs:
 
           gh issue comment "$ISSUE_NUMBER" --body "@$GITHUB_HANDLE is already in the signature registry."
           gh issue edit "$ISSUE_NUMBER" --add-label "signature-duplicate" || true
+          gh issue close "$ISSUE_NUMBER" --reason "not planned"
           echo "found=true" >> "$GITHUB_OUTPUT"
 
       - name: Stop existing pull request
         id: existing-pr
         if: steps.duplicate.outputs.found == 'false'
         env:
-          BRANCH: ${{ steps.request.outputs.branch }}
+          # Every signature branch for a handle shares this prefix; the issue
+          # number is appended. Matching the full branch would only ever catch a
+          # re-run of the same issue, never a second request from the same signer.
+          BRANCH_PREFIX: signature/${{ steps.request.outputs.github }}-
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GITHUB_HANDLE: ${{ steps.request.outputs.github }}
           ISSUE_NUMBER: ${{ steps.request.outputs.issue_number }}
         run: |
-          pr_url="$(gh pr list --head "$BRANCH" --state open --json url --jq '.[0].url // ""')"
+          pr_url="$(gh pr list --state open --json url,headRefName \
+            --jq '[.[] | select(.headRefName | startswith(env.BRANCH_PREFIX))] | .[0].url // ""')"
           echo "url=$pr_url" >> "$GITHUB_OUTPUT"
 
           if [ -n "$pr_url" ]; then
-            gh issue comment "$ISSUE_NUMBER" --body "A signature pull request is already open: $pr_url"
+            gh issue comment "$ISSUE_NUMBER" --body "A signature pull request is already open for @$GITHUB_HANDLE: $pr_url"
+            gh issue edit "$ISSUE_NUMBER" --add-label "signature-pr-created" || true
+            gh issue close "$ISSUE_NUMBER" --reason "not planned"
           fi
 
       - name: Write signature file


### PR DESCRIPTION
## Why

Reviewing a closed signature issue that still carried `signature-request` raised the question of whether labels should be swapped rather than accumulated. They should not — `signature-request` records provenance, and open versus closed already carries state. But the question surfaced three real defects.

**Three exits never closed the issue.** `Close signature issue` is gated on `steps.pull-request.outputs.url != ''`. A duplicate signer, an already-open signature pull request, and an unparseable form all left the issue open with nobody scheduled to close it. Every signer who re-clicked the CTA would leave a stale issue behind.

**The open-pull-request guard could not fire.** It ran `gh pr list --head "$BRANCH"`, and `BRANCH` is `signature/<handle>-<issue-number>`. A second request from the same signer produces a different issue number, so a different branch, so the lookup never matched. Two open pull requests for one signer, since the duplicate guard only checks files already on `main`.

**`requiredText` accepted `_No response_`.** That is the non-empty string GitHub renders for an unanswered field, and only `optionalText` treated it as empty. `display_name` is `required: true` in the form, so the UI hid the hole — but the parser must not depend on that to be correct. A request reaching it another way would name the signer `_No response_`.

## What

- Close the issue on all four exits. `not planned` for duplicate, existing pull request, and invalid form; `completed` stays for the pull-request exit.
- Match `signature/<handle>-` as a prefix, so the guard sees a rival signature pull request from any issue.
- Reject `_No response_` in a required field, with a test.
- The invalid-form comment now says to open a new request. The workflow reacts to `issues.opened`, so editing the issue re-runs nothing — the old wording implied otherwise.

`signature-request` stays on every issue. `is:open label:signature-request` is now a true queue, empty in steady state.

## Verified

Every exit was exercised against a throwaway repository running this exact workflow and script.

| Exit | Issue | Labels | Pull request |
|---|---|---|---|
| Signature accepted | closed `completed` | `+ signature-pr-created` | opened by the bot App |
| Pull request already open | closed `not_planned` | `+ signature-pr-created` | none |
| Duplicate signer | closed `not_planned` | `+ signature-duplicate` | none |
| Invalid form | closed `not_planned` | `+ signature-needs-fix` | none, run red |

The open-pull-request guard was proved on a genuine leftover: a fresh issue found a pull request opened from an earlier, different issue, commented, and closed itself without opening a rival. The old code would have opened a second one.

The invalid exit was proved twice. Under the old parser, `_No response_` in `Display name` sailed through validation and was stopped by the duplicate guard instead — the wrong reason. Under the fixed parser it fails at `Read signature request`, and `Report invalid signature request` reports and closes.

`node --test .github/scripts/read-signature-request.test.js` — 9 pass, 0 fail.