### PR TITLE
feat(cover): open signing modal from cover Sign CTA

### DIFF
--- a/app/src/components/sections/Cover.astro
+++ b/app/src/components/sections/Cover.astro
@@ -1,6 +1,7 @@
 ---
 // Cover — standard splash: a version header, a huge confident title, two entry links.
 // The AIDD mark stays as a faint watermark (parallax hook); two hairlines frame the fold.
+import { SITE } from '~/lib/site';
 ---
 <section class="cover" data-screen-label="Cover">
   <svg class="cover-watermark" viewBox="0 0 100 100" preserveAspectRatio="xMidYMid meet" aria-hidden="true" focusable="false">
@@ -28,7 +29,7 @@
     <div class="cover-foot reveal-word" style="--d:.72s">
       <p class="cover-lede">A standard for building software in the age of AI — written by developers, for developers.</p>
       <nav class="cover-cta" aria-label="Manifesto entry points">
-        <a class="cover-link cover-link-primary" href="#sign" style="--cta-i:0">
+        <a class="cover-link cover-link-primary" href={SITE.signUrl} data-github-url={SITE.signUrl} target="_blank" rel="noopener" style="--cta-i:0">
           <span class="cover-link-icon cover-link-icon-aidd" aria-hidden="true">
             <svg viewBox="0 0 100 100" focusable="false">
               <line x1="8" y1="92" x2="28" y2="62" stroke="currentColor" stroke-width="14" stroke-linecap="round" />

--- a/app/src/components/signature/SignButton.astro
+++ b/app/src/components/signature/SignButton.astro
@@ -6,9 +6,7 @@
 // No query params: the page is static and knows nothing about the visitor. The
 // form carries its own placeholders, which are hints rather than submitted text.
 
-const REPO = 'ai-driven-dev/manifest';
-
-const GITHUB_URL = `https://github.com/${REPO}/issues/new?template=signature.yml`;
+import { SITE } from '~/lib/site';
 
 interface Props {
   /** 'github' (default, bottom CTA) or 'aidd' (animated brand mark, sidebar). */
@@ -18,10 +16,9 @@ interface Props {
 }
 const { logo = 'github', variant = 'default' } = Astro.props;
 ---
-<button 
-  id="sign-manifesto-btn"
+<button
   class:list={['sign-btn', variant === 'sidebar' && 'sign-btn--sidebar']}
-  data-github-url={GITHUB_URL}
+  data-github-url={SITE.signUrl}
   type="button"
   aria-label="Sign and share the manifesto"
 >

--- a/app/src/lib/share.ts
+++ b/app/src/lib/share.ts
@@ -192,8 +192,9 @@ export function initSharePopup(): void {
     }
   });
 
+  const SIGN_TRIGGER = '[data-github-url]';
   document.addEventListener('click', (e) => {
-    const signBtn = (e.target as HTMLElement).closest('#sign-manifesto-btn');
+    const signBtn = (e.target as HTMLElement).closest(SIGN_TRIGGER);
     if (signBtn) {
       e.preventDefault();
       const githubUrl = (signBtn as HTMLElement).dataset.githubUrl || '';

--- a/app/tests/e2e/checklist.spec.ts
+++ b/app/tests/e2e/checklist.spec.ts
@@ -83,7 +83,8 @@ test.describe('web checklist surface', () => {
     await expect(page.locator('main#main')).toHaveCount(1);
     await expect(page.locator('footer')).toHaveCount(1);
     await expect(page.locator('h1')).toHaveCount(1);
-    await expect(page.locator('h2')).toHaveCount(3);
+    // One h2 per homepage doc section: Definition, Values, Principles, Signature.
+    await expect(page.locator('h2')).toHaveCount(4);
     await expect(page.locator('#V-1')).toHaveCount(1);
     await expect(page.locator('#P-01')).toHaveCount(1);
 

--- a/app/tests/e2e/sign.spec.ts
+++ b/app/tests/e2e/sign.spec.ts
@@ -37,9 +37,15 @@ test.describe('signature modal', () => {
     });
   }
 
-  test('with JavaScript off, the cover Sign CTA links straight to the GitHub signature form', async ({ page }) => {
+});
+
+test.describe('signature fallback without JavaScript', () => {
+  test.use({ javaScriptEnabled: false });
+
+  test('the cover Sign CTA is a plain link to the GitHub signature form and opens no modal', async ({ page }) => {
     await page.goto('/');
 
     await expect(page.locator('.cover-link-primary')).toHaveAttribute('href', SIGNATURE_FORM);
+    await expect(page.locator('#share-popup')).toHaveJSProperty('open', false);
   });
 });

--- a/app/tests/e2e/sign.spec.ts
+++ b/app/tests/e2e/sign.spec.ts
@@ -1,40 +1,48 @@
 import { expect, test } from '@playwright/test';
 
-// Both the cover CTA and the bottom button open the modal via the same
-// [data-github-url] click delegation in share.ts.
-test.describe('sign flow', () => {
-  // The share flow ends by opening the GitHub form in a new tab after a 3 s
-  // countdown. Stub it so the tests assert the modal, not the external redirect.
-  test.beforeEach(async ({ page }) => {
-    await page.addInitScript(() => {
-      window.open = () => null;
-    });
-  });
+// The signature form URL every Sign entry point must reach.
+const SIGNATURE_FORM = /github\.com\/.*issues\/new\?template=signature\.yml/;
 
-  test('cover Sign opens the share modal instead of scrolling to #sign', async ({ page }) => {
+// Signing ends by opening the GitHub form in a new tab. Capture window.open so
+// the tests assert that destination instead of following the real redirect.
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    (window as unknown as { __opened: string[] }).__opened = [];
+    window.open = (url) => {
+      (window as unknown as { __opened: string[] }).__opened.push(String(url ?? ''));
+      return null;
+    };
+  });
+});
+
+async function redirectedToSignatureForm(page: import('@playwright/test').Page) {
+  const opened = await page.evaluate(() => (window as unknown as { __opened: string[] }).__opened);
+  return opened.some((url) => SIGNATURE_FORM.test(url));
+}
+
+test.describe('signature modal', () => {
+  test('the cover Sign CTA opens the modal, then redirects to the GitHub signature form', async ({ page }) => {
     await page.goto('/');
 
-    const cover = page.locator('.cover-link-primary');
-    await expect(cover).toBeVisible();
-    // It is a real anchor to the GitHub form (works with JS off).
-    await expect(cover).toHaveAttribute('href', /github\.com\/.*issues\/new\?template=signature\.yml/);
+    await page.locator('.cover-link-primary').click();
 
-    const popup = page.locator('#share-popup');
-    await expect(popup).not.toHaveJSProperty('open', true);
-
-    await cover.click();
-
-    // JS intercepted the anchor: modal opens and the page did not scroll/navigate.
-    await expect(popup).toHaveJSProperty('open', true);
-    expect(new URL(page.url()).pathname).toBe('/');
+    await expect(page.locator('#share-popup')).toHaveJSProperty('open', true);
+    expect(new URL(page.url()).pathname).toBe('/'); // the page itself stays put
+    await expect.poll(() => redirectedToSignatureForm(page), { timeout: 6000 }).toBe(true);
   });
 
-  test('bottom Sign button still opens the same modal', async ({ page }) => {
+  test('the bottom Sign CTA opens the modal, then redirects to the GitHub signature form', async ({ page }) => {
     await page.goto('/');
 
-    const popup = page.locator('#share-popup');
     await page.locator('.sign-cta .sign-btn').click();
 
-    await expect(popup).toHaveJSProperty('open', true);
+    await expect(page.locator('#share-popup')).toHaveJSProperty('open', true);
+    await expect.poll(() => redirectedToSignatureForm(page), { timeout: 6000 }).toBe(true);
+  });
+
+  test('with JavaScript off, the cover Sign CTA links straight to the GitHub signature form', async ({ page }) => {
+    await page.goto('/');
+
+    await expect(page.locator('.cover-link-primary')).toHaveAttribute('href', SIGNATURE_FORM);
   });
 });

--- a/app/tests/e2e/sign.spec.ts
+++ b/app/tests/e2e/sign.spec.ts
@@ -20,25 +20,24 @@ async function redirectedToSignatureForm(page: import('@playwright/test').Page) 
   return opened.some((url) => SIGNATURE_FORM.test(url));
 }
 
+// Every Sign entry point runs the one shared flow, so assert it once per trigger.
+const SIGN_TRIGGERS = [
+  { label: 'cover Sign CTA', selector: '.cover-link-primary' },
+  { label: 'bottom Sign CTA', selector: '.sign-cta .sign-btn' },
+];
+
 test.describe('signature modal', () => {
-  test('the cover Sign CTA opens the modal, then redirects to the GitHub signature form', async ({ page }) => {
-    await page.goto('/');
+  for (const trigger of SIGN_TRIGGERS) {
+    test(`the ${trigger.label} opens the modal, then redirects to the GitHub signature form`, async ({ page }) => {
+      await page.goto('/');
 
-    await page.locator('.cover-link-primary').click();
+      await page.locator(trigger.selector).click();
 
-    await expect(page.locator('#share-popup')).toHaveJSProperty('open', true);
-    expect(new URL(page.url()).pathname).toBe('/'); // the page itself stays put
-    await expect.poll(() => redirectedToSignatureForm(page), { timeout: 6000 }).toBe(true);
-  });
-
-  test('the bottom Sign CTA opens the modal, then redirects to the GitHub signature form', async ({ page }) => {
-    await page.goto('/');
-
-    await page.locator('.sign-cta .sign-btn').click();
-
-    await expect(page.locator('#share-popup')).toHaveJSProperty('open', true);
-    await expect.poll(() => redirectedToSignatureForm(page), { timeout: 6000 }).toBe(true);
-  });
+      await expect(page.locator('#share-popup')).toHaveJSProperty('open', true);
+      expect(new URL(page.url()).pathname).toBe('/'); // the page itself stays put
+      await expect.poll(() => redirectedToSignatureForm(page), { timeout: 6000 }).toBe(true);
+    });
+  }
 
   test('with JavaScript off, the cover Sign CTA links straight to the GitHub signature form', async ({ page }) => {
     await page.goto('/');

--- a/app/tests/e2e/sign.spec.ts
+++ b/app/tests/e2e/sign.spec.ts
@@ -1,0 +1,40 @@
+import { expect, test } from '@playwright/test';
+
+// Both the cover CTA and the bottom button open the modal via the same
+// [data-github-url] click delegation in share.ts.
+test.describe('sign flow', () => {
+  // The share flow ends by opening the GitHub form in a new tab after a 3 s
+  // countdown. Stub it so the tests assert the modal, not the external redirect.
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      window.open = () => null;
+    });
+  });
+
+  test('cover Sign opens the share modal instead of scrolling to #sign', async ({ page }) => {
+    await page.goto('/');
+
+    const cover = page.locator('.cover-link-primary');
+    await expect(cover).toBeVisible();
+    // It is a real anchor to the GitHub form (works with JS off).
+    await expect(cover).toHaveAttribute('href', /github\.com\/.*issues\/new\?template=signature\.yml/);
+
+    const popup = page.locator('#share-popup');
+    await expect(popup).not.toHaveJSProperty('open', true);
+
+    await cover.click();
+
+    // JS intercepted the anchor: modal opens and the page did not scroll/navigate.
+    await expect(popup).toHaveJSProperty('open', true);
+    expect(new URL(page.url()).pathname).toBe('/');
+  });
+
+  test('bottom Sign button still opens the same modal', async ({ page }) => {
+    await page.goto('/');
+
+    const popup = page.locator('#share-popup');
+    await page.locator('.sign-cta .sign-btn').click();
+
+    await expect(popup).toHaveJSProperty('open', true);
+  });
+});

--- a/app/tests/e2e/sign.spec.ts
+++ b/app/tests/e2e/sign.spec.ts
@@ -38,14 +38,3 @@ test.describe('signature modal', () => {
   }
 
 });
-
-test.describe('signature fallback without JavaScript', () => {
-  test.use({ javaScriptEnabled: false });
-
-  test('the cover Sign CTA is a plain link to the GitHub signature form and opens no modal', async ({ page }) => {
-    await page.goto('/');
-
-    await expect(page.locator('.cover-link-primary')).toHaveAttribute('href', SIGNATURE_FORM);
-    await expect(page.locator('#share-popup')).toHaveJSProperty('open', false);
-  });
-});

--- a/app/tests/e2e/sign.spec.ts
+++ b/app/tests/e2e/sign.spec.ts
@@ -1,10 +1,9 @@
 import { expect, test } from '@playwright/test';
 
-// The signature form URL every Sign entry point must reach.
 const SIGNATURE_FORM = /github\.com\/.*issues\/new\?template=signature\.yml/;
 
-// Signing ends by opening the GitHub form in a new tab. Capture window.open so
-// the tests assert that destination instead of following the real redirect.
+// Capture window.open so the tests assert the redirect target instead of
+// following it into a real new tab.
 test.beforeEach(async ({ page }) => {
   await page.addInitScript(() => {
     (window as unknown as { __opened: string[] }).__opened = [];
@@ -20,7 +19,6 @@ async function redirectedToSignatureForm(page: import('@playwright/test').Page) 
   return opened.some((url) => SIGNATURE_FORM.test(url));
 }
 
-// Every Sign entry point runs the one shared flow, so assert it once per trigger.
 const SIGN_TRIGGERS = [
   { label: 'cover Sign CTA', selector: '.cover-link-primary' },
   { label: 'bottom Sign CTA', selector: '.sign-cta .sign-btn' },
@@ -34,7 +32,7 @@ test.describe('signature modal', () => {
       await page.locator(trigger.selector).click();
 
       await expect(page.locator('#share-popup')).toHaveJSProperty('open', true);
-      expect(new URL(page.url()).pathname).toBe('/'); // the page itself stays put
+      expect(new URL(page.url()).pathname).toBe('/');
       await expect.poll(() => redirectedToSignatureForm(page), { timeout: 6000 }).toBe(true);
     });
   }

--- a/app/tests/e2e/visual.spec.ts
+++ b/app/tests/e2e/visual.spec.ts
@@ -19,6 +19,9 @@ for (const v of VIEWPORTS) {
     await page.goto('/');
     await page.waitForLoadState('networkidle');
     await page.waitForTimeout(1500);
+    // Scrollbar gutter width is OS-dependent (0px overlay vs 15px classic); hide it
+    // so the captured `.cover` width is machine-independent.
+    await page.evaluate(() => { document.documentElement.style.overflow = 'hidden'; });
     const astroBuf = await page.locator('.cover').screenshot({ animations: 'disabled' });
 
     expect(astroBuf.byteLength).toBeGreaterThan(0);


### PR DESCRIPTION
## What

The cover **Sign** CTA no longer scrolls to the bottom registry section — it now runs the same flow as the bottom Sign button: open the share modal (3 s countdown + confetti) then redirect to the GitHub signature form.

## How

- Click delegation keys off `[data-github-url]` instead of the `#sign-manifesto-btn` id → one seam for the cover link + both `SignButton` instances.
- Cover Sign stays a real `<a href={SITE.signUrl}>` — reaches the form with JS off; JS intercepts for the modal.
- Removed the duplicate `id="sign-manifesto-btn"` (was rendered twice, invalid HTML).
- `SignButton` now uses the canonical `SITE.signUrl` (dropped a local URL duplicate).

## Tests

- New `sign.spec.ts` covers both cover + bottom sign paths (modal opens, no navigation).
- Fixed two pre-existing local-only specs unrelated to the feature: stale `h2` count (3 → 4) and a scrollbar-fragile cover snapshot (width now OS-independent).
- Full e2e green (16/16); `sign.spec` stable under repeat.

## Tradeoff

Top-of-page visitors no longer get the guided scroll to the signature wall/registry — it becomes scroll-only. Accepted.

## Note

Visual snapshot baselines are gitignored (`**/*-snapshots/`) → the cover-≤1% regression test has no committed reference and runs local-only (CI runs build + unit + LOC, not Playwright). Pre-existing; left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)