### PR TITLE
fix(signature): write signature file when statement is empty

### DIFF
--- a/.github/workflows/signature-pr.yml
+++ b/.github/workflows/signature-pr.yml
@@ -2,7 +2,7 @@ name: Signature PR
 
 on:
   issues:
-    types: [opened]
+    types: [opened, labeled]
 
 # The job acts as the signature bot App, not as GITHUB_TOKEN, so the workflow
 # token itself needs nothing beyond reading the checked-out ref.
@@ -18,7 +18,15 @@ jobs:
     # The label is applied server-side by the Issue Form and cannot be set by a
     # contributor without triage rights. Title and body can, so they are not a
     # trigger. Delete the label and this workflow stops firing.
-    if: github.event.issue.state == 'open' && contains(github.event.issue.labels.*.name, 'signature-request')
+    #
+    # Adding signature-retry reprocesses a request that failed. It is a label,
+    # so it stays triage-only, and it is never applied at creation or by the
+    # bot: the Issue Form sets signature-request and the workflow sets
+    # signature-*, so neither can fire the labeled path.
+    if: >-
+      github.event.issue.state == 'open'
+      && contains(github.event.issue.labels.*.name, 'signature-request')
+      && (github.event.action != 'labeled' || github.event.label.name == 'signature-retry')
     runs-on: ubuntu-latest
     steps:
       # A pull request opened by GITHUB_TOKEN leaves its Validate run stuck on
@@ -109,12 +117,14 @@ jobs:
           STATEMENT_YAML: ${{ steps.request.outputs.statement_yaml }}
         run: |
           mkdir -p "$(dirname "$SIGNATURE_PATH")"
+          # A trailing `[ -n "$X" ] && echo` would make the group, and so the
+          # step, exit 1 whenever the last optional field is empty.
           {
             echo "github: $GITHUB_HANDLE"
             echo "name: $NAME_YAML"
-            [ -n "$LINKEDIN_YAML" ] && echo "linkedin: $LINKEDIN_YAML"
-            [ -n "$AFFILIATION_YAML" ] && echo "affiliation: $AFFILIATION_YAML"
-            [ -n "$STATEMENT_YAML" ] && echo "statement: $STATEMENT_YAML"
+            if [ -n "$LINKEDIN_YAML" ]; then echo "linkedin: $LINKEDIN_YAML"; fi
+            if [ -n "$AFFILIATION_YAML" ]; then echo "affiliation: $AFFILIATION_YAML"; fi
+            if [ -n "$STATEMENT_YAML" ]; then echo "statement: $STATEMENT_YAML"; fi
           } > "$SIGNATURE_PATH"
 
       - name: Commit signature file


### PR DESCRIPTION
## The bug

The `Write signature file` step ended with:

```bash
[ -n "$STATEMENT_YAML" ] && echo "statement: $STATEMENT_YAML"
```

A step's script exits with the status of its last command. That `{ ... }` group was the last command, and the group's status is its last inner command — the failing `[` test. So a blank statement made the step exit 1 and no pull request was ever opened.

This is not a `set -e` issue. It fails identically without `-e`:

```
$ STATEMENT_YAML="" bash -c '{ echo a; [ -n "$STATEMENT_YAML" ] && echo s; } >/dev/null'; echo $?
1
```

Only the *last* optional field matters, which is why it looked intermittent: a blank affiliation with a statement present passed fine. Every signer who left the statement blank failed.

Seven requests hit this: #65, #66, #69, #80, #83, #84, #90.

## The fix

`if` blocks, so the group always ends on a zero status regardless of which optional fields are empty. Verified against the real inputs from #90 (blank statement, blank affiliation): step exits 0 and emits schema-valid YAML.

## Retry path

Adds a `signature-retry` label trigger so a maintainer can reprocess a stuck request — `issues: opened` alone cannot reprocess an existing issue, and the workflow always runs from `main`.

A dedicated label rather than re-applying `signature-request`: the Issue Form applies `signature-request` at creation, so keying the labeled path on it would double-fire every new signup. The workflow's own labels are all `signature-*`, so neither can fire the labeled path. Adding a label still requires triage rights, so the security boundary is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)