### PR TITLE
fix(manifesto): align canonical content

### DIFF
--- a/app/src/components/layout/SpecIndex.astro
+++ b/app/src/components/layout/SpecIndex.astro
@@ -27,7 +27,7 @@ const count = (await getCollection('signatories')).length;
     <a class="si-link" href="#sign" data-spy="sign">Sign</a>
   </nav>
   <div class="si-sign">
-    <p class="si-sign-phrase">Written in 🇫🇷</p>
+    <p class="si-sign-phrase">Created in France 🇫🇷</p>
     <SignButton logo="aidd" variant="sidebar" />
     <p class="si-sign-count"><strong>{count}</strong> signatures.</p>
   </div>

--- a/app/src/components/layout/SpecIndex.astro
+++ b/app/src/components/layout/SpecIndex.astro
@@ -20,6 +20,7 @@ const count = (await getCollection('signatories')).length;
     <span class="si-ver">v{SITE.version}</span>
   </div>
   <nav class="si-nav">
+    <a class="si-link" href="#preamble" data-spy="preamble">Preamble</a>
     <a class="si-link" href="#definition" data-spy="definition">Definition</a>
     <a class="si-link" href="#values" data-spy="values">Values</a>
     <a class="si-link" href="#principles" data-spy="principles">Principles</a>

--- a/app/src/components/principles/PrincipleDemo.astro
+++ b/app/src/components/principles/PrincipleDemo.astro
@@ -76,4 +76,4 @@ const demos = [
   transferableDemo,
 ];
 ---
-<div class={`p-demo demo-${number}`} aria-label={`Visual demonstration for commitment ${number}`} set:html={demos[index] ?? demos[0]} />
+<div class={`p-demo demo-${number}`} aria-label={`Visual demonstration for principle ${number}`} set:html={demos[index] ?? demos[0]} />

--- a/app/src/components/sections/Definition.astro
+++ b/app/src/components/sections/Definition.astro
@@ -1,5 +1,5 @@
 ---
-import { ENTRY, SYNONYMS } from '~/content/lexicon';
+import { ENTRY, RELATED_PRACTICES } from '~/content/lexicon';
 import VersusSchemas from '~/components/definition/VersusSchemas.astro';
 ---
 <section id="definition" class="definition">
@@ -16,8 +16,8 @@ import VersusSchemas from '~/components/definition/VersusSchemas.astro';
     </p>
     <p class="lex-def" set:html={ENTRY.def} />
     <p class="lex-syn">
-      <span class="lex-tag">Also known as</span>
-      <span class="lex-syn-terms">{SYNONYMS.join(', ')}</span>
+      <span class="lex-tag">Related practices</span>
+      <span class="lex-syn-terms">{RELATED_PRACTICES.join(', ')}</span>
     </p>
   </article>
 

--- a/app/src/components/sections/Preamble.astro
+++ b/app/src/components/sections/Preamble.astro
@@ -1,9 +1,7 @@
 ---
+import { PREAMBLE } from '~/content/preamble';
 ---
 <section id="preamble" class="preamble">
-  <div class="label">Preamble</div>
-  <p>
-    As AI-Driven Developers, we are discovering <em>better ways</em> of building software
-    by working with AI as a deliberate partner — and helping others do the same.
-  </p>
+  <h2 class="label">Preamble</h2>
+  <p set:html={PREAMBLE} />
 </section>

--- a/app/src/components/sections/Principles.astro
+++ b/app/src/components/sections/Principles.astro
@@ -4,7 +4,7 @@ import PrincipleGrid from '~/components/principles/PrincipleGrid.astro';
 <section id="principles" class="principles">
   <div class="chapter-open reveal">
     <div class="chapter-body">
-      <h2>12 commitments for durable <em>AI-driven development.</em></h2>
+      <h2>12 principles for durable <em>AI-driven development.</em></h2>
       <div class="chapter-lede">
         <svg class="fleuron" width="44" height="44" viewBox="0 0 44 44" fill="none" aria-hidden="true">
           <path d="M4 22 L40 22 M22 4 L22 40 M10 10 L34 34 M34 10 L10 34" stroke="currentColor" stroke-width="0.8" opacity=".6"/>

--- a/app/src/components/values/ValueArt.astro
+++ b/app/src/components/values/ValueArt.astro
@@ -77,11 +77,11 @@ const { anim } = Astro.props;
   <div class="value-art" data-anim="v4">
     <div class="va-col va-good">
       <div class="va-col-head"><span class="va-col-label">outcome</span><span class="va-col-badge">do</span></div>
-      <pre><span class="va-l" style="--i:0">features shipped   <span class="va-ok">✓</span></span>
-<span class="va-l" style="--i:1">bugs avoided       <span class="va-ok">✓</span></span>
-<span class="va-l" style="--i:2">users impacted   <span class="va-ok">+410</span></span>
+      <pre><span class="va-l" style="--i:0">users helped      <span class="va-ok">+410</span></span>
+<span class="va-l" style="--i:1">task time          <span class="va-ok">-32%</span></span>
+<span class="va-l" style="--i:2">incidents avoided    <span class="va-ok">✓</span></span>
 <span class="va-l" style="--i:3"><span class="va-dim2">———————————————</span></span>
-<span class="va-l" style="--i:4"><span class="va-dim2">the business moved.</span><span class="va-cursor" style="--cd:1.4s"></span></span></pre>
+<span class="va-l" style="--i:4"><span class="va-dim2">outcomes improved.</span><span class="va-cursor" style="--cd:1.4s"></span></span></pre>
     </div>
     <div class="va-sep"></div>
     <div class="va-col va-bad">

--- a/app/src/content/icons.ts
+++ b/app/src/content/icons.ts
@@ -55,9 +55,9 @@ export const ICONS: Record<IconKey, IconDef> = {
       <path pathLength="100" d="M16 12.5 C 12 12.5, 12 19.5, 16 19.5 C 20 19.5, 20 12.5, 16 12.5" fill="none"/>
       <circle pathLength="100" cx="16" cy="16" r="1.5" fill="currentColor" stroke="none"/>`,
   },
-  // V-4 Impact — a target with an arrow planted at the centre.
+  // V-4 Outcome — a target with an arrow planted at the centre.
   'V-4': {
-    label: 'Impact — an arrow striking the centre of a target',
+    label: 'Outcome — an arrow striking the centre of a target',
     paths: `
       <path pathLength="100" d="M16 5.5 C 10 5.5, 5.5 10, 5.5 16 C 5.5 22, 10 26.5, 16 26.5 C 22 26.5, 26.5 22, 26.5 16 C 26.5 11, 23 6.5, 18 5.7" fill="none"/>
       <path pathLength="100" d="M16 11 C 13.2 11, 11 13.2, 11 16 C 11 18.8, 13.2 21, 16 21 C 18.6 21, 20.8 19, 21 16.4" fill="none"/>

--- a/app/src/content/lexicon.ts
+++ b/app/src/content/lexicon.ts
@@ -1,6 +1,6 @@
-// Lexicon — the dictionary entry for "AI-Driven Development", the alternative
-// labels others use for the same shift (SEO surface), and the AIDD vs vibe
-// coding contrast. Editorial content; rendered by sections/Definition.astro.
+// Lexicon — the dictionary entry for "AI-Driven Development", adjacent
+// practices, and the AIDD vs vibe coding contrast. Editorial content; rendered
+// by sections/Definition.astro.
 // HTML is allowed in `def` (kept minimal, only <em>).
 
 export interface LexiconEntry {
@@ -31,16 +31,12 @@ export const ENTRY: LexiconEntry = {
   def: "A way of building software in which a developer works <em>with AI as a deliberate partner</em> — planning, decomposing, and reviewing every change — while remaining the architect accountable for what ships.",
 };
 
-/** Alternative labels others use for the same practice — the SEO surface. */
-export const SYNONYMS: string[] = [
+/** Practices that overlap with AIDD without being equivalent to it. */
+export const RELATED_PRACTICES: string[] = [
   "AI-assisted development",
-  "AI-assisted coding",
-  "AI-augmented engineering",
-  "AI-native development",
+  "AI pair programming",
   "agentic coding",
   "spec-driven development",
-  "prompt-driven development",
-  "AI pair programming",
   "context engineering",
 ];
 

--- a/app/src/content/preamble.ts
+++ b/app/src/content/preamble.ts
@@ -1,0 +1,3 @@
+/** Canonical preamble shared by the web page and machine-readable exports. */
+export const PREAMBLE =
+  'As AI-Driven Developers, we are discovering <em>better ways</em> of building software by working with AI as a deliberate partner — and helping others do the same.';

--- a/app/src/content/principles.ts
+++ b/app/src/content/principles.ts
@@ -9,7 +9,7 @@ export interface Principle {
   lead: string;
   /** HTML sub paragraph */
   sub: string;
-  /** Compact framework trace shown in the commitments table */
+  /** Compact framework trace associated with the principle */
   proof: string;
   /** Long-form essay paragraphs (HTML), shown in focus overlay (optional) */
   essay?: string[];

--- a/app/src/content/values.ts
+++ b/app/src/content/values.ts
@@ -2,7 +2,7 @@
  * Each "value" pairs a left (preferred) concept with a right (devalued) concept,
  * shown in the values plate. The four values are the core of the manifesto, laid
  * out as a 2×2 quadrant (see `Quadrant.astro`) that builds up the new shape of a
- * developer's value: Method · Ownership · Understanding · Impact. Visual ASCII art
+ * developer's value: Method · Ownership · Understanding · Outcome. Visual ASCII art
  * is rendered inline (see `ValueArt.astro`). This file holds the structured content.
  */
 export interface ValueEntry {
@@ -61,8 +61,8 @@ export const VALUES: ValueEntry[] = [
     id: "V-4",
     left: "Outcome",
     right: "Output",
-    quad: "Impact",
-    note: 'Ship <em class="emph">impact<svg class="und" aria-hidden="true" viewBox="0 0 100 7" preserveAspectRatio="none"><path d="M2 4 Q 32 2, 56 5 T 98 4"/></svg></em>. Not <em class="emph">output<svg class="und" aria-hidden="true" viewBox="0 0 100 7" preserveAspectRatio="none"><path d="M2 5 Q 30 3, 54 6 T 98 3"/></svg></em>.',
-    body: "<strong>Writing code is easy. Building product is not</strong>.<br>Ship small, iterate fast, short feedback loops — avoid vanity metrics. The only number that serves is the business.",
+    quad: "Outcome",
+    note: 'Ship <em class="emph">outcomes<svg class="und" aria-hidden="true" viewBox="0 0 100 7" preserveAspectRatio="none"><path d="M2 4 Q 32 2, 56 5 T 98 4"/></svg></em>. Not <em class="emph">output<svg class="und" aria-hidden="true" viewBox="0 0 100 7" preserveAspectRatio="none"><path d="M2 5 Q 30 3, 54 6 T 98 3"/></svg></em>.',
+    body: "<strong>Writing code is easy. Creating useful outcomes is not</strong>.<br>Ship small, learn quickly, and measure results for users, product reliability, and the business — not lines, tokens, or commits.",
   },
 ];

--- a/app/src/lib/manifesto.test.ts
+++ b/app/src/lib/manifesto.test.ts
@@ -9,10 +9,22 @@ describe('manifesto data helpers', () => {
     expect(data.version).toBe('1.1.1');
     expect(data.values).toHaveLength(4);
     expect(data.principles).toHaveLength(12);
+    expect(data.relatedPractices).toEqual([
+      'AI-assisted development',
+      'AI pair programming',
+      'agentic coding',
+      'spec-driven development',
+      'context engineering',
+    ]);
     expect(data.values[0]).toMatchObject({
       id: 'V-1',
       preferred: 'Method',
       weighedAgainst: 'Model',
+    });
+    expect(data.values[3]).toMatchObject({
+      preferred: 'Outcome',
+      weighedAgainst: 'Output',
+      quadrant: 'Outcome',
     });
   });
 
@@ -21,6 +33,10 @@ describe('manifesto data helpers', () => {
 
     expect(markdown).toContain('# The Manifesto for AI-Driven Development');
     expect(markdown).toContain('Version 1.1.1');
+    expect(markdown).toContain('## Preamble');
+    expect(markdown).toContain('Related practices: AI-assisted development');
+    expect(markdown).not.toContain('Also known as:');
+    expect(markdown).not.toContain('prompt-driven development');
     expect(markdown).toContain('## Value 1: Method over Model');
     expect(markdown).toContain('## Principle 12');
     expect(markdown).toContain('Canonical URL: https://www.ai-driven-development.org/');

--- a/app/src/lib/manifesto.ts
+++ b/app/src/lib/manifesto.ts
@@ -1,6 +1,7 @@
 import { PRINCIPLES } from '~/content/principles';
+import { PREAMBLE } from '~/content/preamble';
 import { VALUES } from '~/content/values';
-import { ENTRY, SYNONYMS, VERSUS } from '~/content/lexicon';
+import { ENTRY, RELATED_PRACTICES, VERSUS } from '~/content/lexicon';
 import { absoluteUrl, SITE, stripHtml } from '~/lib/site';
 
 export function getManifestoMarkdown(): string {
@@ -26,7 +27,7 @@ Version ${SITE.version}
 
 ## Preamble
 
-As AI-Driven Developers, we are discovering better ways of building software by working with AI as a deliberate partner, and helping others do the same.
+${stripHtml(PREAMBLE)}
 
 ## Definition
 
@@ -34,7 +35,7 @@ As AI-Driven Developers, we are discovering better ways of building software by 
 
 ${stripHtml(ENTRY.def)}
 
-Also known as: ${SYNONYMS.join(', ')}.
+Related practices: ${RELATED_PRACTICES.join(', ')}.
 
 ### AIDD vs vibe coding
 
@@ -69,6 +70,7 @@ export function getManifestoJson() {
     datePublished: SITE.publishedDate,
     dateModified: SITE.modifiedDate,
     repository: SITE.repoUrl,
+    relatedPractices: RELATED_PRACTICES,
     values: VALUES.map((value) => ({
       id: value.id,
       number: value.n,
@@ -135,6 +137,7 @@ export function getHomeJsonLd() {
         'AI-assisted software development',
         'software engineering',
         'developer practice',
+        ...manifesto.relatedPractices,
       ],
       hasPart: [
         ...manifesto.values.map((value) => ({
@@ -159,7 +162,7 @@ export function getHomeJsonLd() {
       '@type': 'DefinedTerm',
       '@id': `${absoluteUrl('/')}#aidd`,
       name: ENTRY.headword,
-      alternateName: [ENTRY.abbr, ...SYNONYMS],
+      alternateName: [ENTRY.abbr],
       description: stripHtml(ENTRY.def),
       url: `${absoluteUrl('/')}#definition`,
       inDefinedTermSet: {

--- a/app/src/pages/index.astro
+++ b/app/src/pages/index.astro
@@ -3,6 +3,7 @@ import Page from '~/components/layout/Page.astro';
 import SpecIndex from '~/components/layout/SpecIndex.astro';
 import Footer from '~/components/layout/Footer.astro';
 import Cover from '~/components/sections/Cover.astro';
+import Preamble from '~/components/sections/Preamble.astro';
 import Definition from '~/components/sections/Definition.astro';
 import Values from '~/components/sections/Values.astro';
 import Principles from '~/components/sections/Principles.astro';
@@ -18,6 +19,7 @@ import ClientApp from '~/components/ClientApp.astro';
       <div class="doc-layout">
         <SpecIndex />
         <div class="doc">
+          <Preamble />
           <Definition />
           <Values />
           <Principles />

--- a/app/src/styles/sections/principles.css
+++ b/app/src/styles/sections/principles.css
@@ -1,4 +1,4 @@
-/* ============ PRINCIPLES — twelve commitments, citable reference grid ============ */
+/* ============ PRINCIPLES — twelve principles, citable reference grid ============ */
 .principles{ padding: 0 0 clamp(16px, 2.5vh, 28px); }
 .principles .chapter-open{
   padding: clamp(48px, 7vh, 76px) 0 clamp(24px, 4vh, 40px);

--- a/app/src/styles/sections/print.css
+++ b/app/src/styles/sections/print.css
@@ -76,6 +76,7 @@
     }
 
     .cover,
+    .preamble,
     .definition,
     .values,
     .principles,
@@ -145,6 +146,7 @@
         font-size: 14pt !important;
     }
 
+    .preamble,
     .definition,
     .values,
     .principles,

--- a/app/tests/e2e/checklist.spec.ts
+++ b/app/tests/e2e/checklist.spec.ts
@@ -89,6 +89,7 @@ test.describe('web checklist surface', () => {
     await expect(page.locator('#definition')).toContainText('Related practices');
     await expect(page.locator('#principles h2')).toContainText('12 principles');
     await expect(page.locator('#values')).toContainText('Creating useful outcomes is not');
+    await expect(page.locator('.si-sign-phrase')).toHaveText('Created in France 🇫🇷');
     await expect(page.locator('#V-1')).toHaveCount(1);
     await expect(page.locator('#P-01')).toHaveCount(1);
 

--- a/app/tests/e2e/checklist.spec.ts
+++ b/app/tests/e2e/checklist.spec.ts
@@ -83,8 +83,12 @@ test.describe('web checklist surface', () => {
     await expect(page.locator('main#main')).toHaveCount(1);
     await expect(page.locator('footer')).toHaveCount(1);
     await expect(page.locator('h1')).toHaveCount(1);
-    // One h2 per homepage doc section: Definition, Values, Principles, Signature.
-    await expect(page.locator('h2')).toHaveCount(4);
+    // Five document-section headings plus the signature preflight dialog heading.
+    await expect(page.locator('h2')).toHaveCount(6);
+    await expect(page.locator('#preamble')).toContainText('As AI-Driven Developers');
+    await expect(page.locator('#definition')).toContainText('Related practices');
+    await expect(page.locator('#principles h2')).toContainText('12 principles');
+    await expect(page.locator('#values')).toContainText('Creating useful outcomes is not');
     await expect(page.locator('#V-1')).toHaveCount(1);
     await expect(page.locator('#P-01')).toHaveCount(1);
 

--- a/app/tests/e2e/print.spec.ts
+++ b/app/tests/e2e/print.spec.ts
@@ -5,11 +5,12 @@ test.describe('print rendering', () => {
     await page.emulateMedia({ media: 'print' });
     await page.goto('/', { waitUntil: 'domcontentloaded' });
 
-    for (const selector of ['.cover', '#definition', '#values', '#principles', '#sign', 'footer.doc-footer']) {
+    for (const selector of ['.cover', '#preamble', '#definition', '#values', '#principles', '#sign', 'footer.doc-footer']) {
       await expect(page.locator(selector), `${selector} should render for print`).toBeVisible();
     }
 
     await expect(page.locator('h1.cover-title')).toContainText(/AI-Driven\s+Development\s+Manifesto/);
+    await expect(page.locator('#preamble')).toContainText('As AI-Driven Developers');
     await expect(page.locator('#definition')).toContainText('A way of building software');
     await expect(page.locator('#values')).toContainText('Bet on the method, not the model');
     await expect(page.locator('#principles')).toContainText('Do not delegate what you cannot evaluate');


### PR DESCRIPTION
## Other change

Aligns the manifesto's public page and machine-readable representations around one canonical editorial vocabulary.

### What changed

- restores the preamble on the web page and sources it from shared editorial content
- replaces false "Also known as" equivalences with a shorter list of related practices
- uses "Principles" consistently across visible and accessible copy
- standardizes the fourth value on "Outcome" and replaces output metrics with user and reliability outcomes
- keeps Markdown, JSON, JSON-LD, print, and the web page aligned

### Impact

Readers now encounter the same preamble, terminology, and value definitions regardless of format. Related AI development practices are no longer presented as exact synonyms for AIDD.

### Root cause

Editorial copy had been duplicated across components and exports, while adjacent concepts had accumulated different labels in the UI, diagrams, and structured data.

### Verification

- [x] `npm test` — 52 tests
- [x] `npm run build`
- [x] `npx playwright test tests/e2e/checklist.spec.ts tests/e2e/print.spec.ts` — 8 tests
- [x] `bash tests/check-component-loc.sh`
- [x] desktop and mobile visual verification
