### PR TITLE
ci(runtime): harden automatic runtime updates

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,14 +45,14 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           # Full history so the signature-date generator can read each
           # signatory file's add commit (git log --diff-filter=A).
           fetch-depth: 0
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -60,7 +60,7 @@ jobs:
 
       - name: Extract metadata (tags, labels)
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -68,14 +68,14 @@ jobs:
             type=raw,value=latest
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
       - name: Set up Node.js
         # The self-hosted runner has no node on PATH; setup-node provides it for
         # the generator step below.
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
-          node-version: '24'
+          node-version: 'lts/*'
 
       - name: Generate signature dates from git
         # Derives signatures' dates from git history into
@@ -85,7 +85,7 @@ jobs:
 
       - name: Build and push Docker image
         id: build
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: ./app
           file: ./app/Dockerfile
@@ -116,17 +116,52 @@ jobs:
           GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GHCR_USER: ${{ github.actor }}
         run: |
-          set -e
+          set -Eeuo pipefail
           cd "$DEPLOY_DIR"
+
+          rollback_ref=""
+          rollback() {
+            [ -n "$rollback_ref" ] || return 1
+            override="$(mktemp)"
+            printf 'services:\n  web:\n    image: %s\n' "$rollback_ref" >"$override"
+            docker compose \
+              -f docker-compose.yml \
+              -f "$override" \
+              up -d --no-deps --no-build --pull never --force-recreate web
+            rm -f "$override"
+
+            for _ in $(seq 1 30); do
+              status="$(docker inspect --format='{{.State.Health.Status}}' "$CONTAINER_NAME" 2>/dev/null || true)"
+              [ "$status" = healthy ] && return 0
+              sleep 2
+            done
+            return 1
+          }
+
+          fail_deploy() {
+            printf 'ERROR: %s\n' "$1" >&2
+            docker logs --tail 80 "$CONTAINER_NAME" 2>/dev/null || true
+            if ! rollback; then
+              printf 'ERROR: rollback failed or no previous image was available\n' >&2
+            fi
+            exit 1
+          }
 
           echo "=== GHCR login (ephemeral token) ==="
           echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin
+          trap 'docker logout ghcr.io >/dev/null 2>&1 || true' EXIT
+
+          current_image="$(docker inspect --format '{{.Image}}' "$CONTAINER_NAME" 2>/dev/null || true)"
+          if [ -n "$current_image" ]; then
+            rollback_ref="aidd-rollback/manifest:$(date -u +%Y%m%dT%H%M%SZ)"
+            docker image tag "$current_image" "$rollback_ref"
+          fi
 
           echo "=== Pulling latest image ==="
-          docker compose pull
+          docker compose pull || fail_deploy "image pull failed"
 
           echo "=== Deploying ==="
-          docker compose up -d --remove-orphans
+          docker compose up -d --remove-orphans || fail_deploy "container recreation failed"
 
           echo "=== Waiting for healthy ==="
           for i in $(seq 1 20); do
@@ -136,9 +171,7 @@ jobs:
               break
             fi
             if [ "$i" -eq 20 ]; then
-              echo "ERROR: Container not healthy after 100s"
-              docker logs --tail 30 "$CONTAINER_NAME"
-              exit 1
+              fail_deploy "container not healthy after 100s"
             fi
             sleep 5
           done
@@ -146,10 +179,8 @@ jobs:
           echo "=== Smoke test ==="
           CONTAINER_IP=$(docker inspect --format='{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "$CONTAINER_NAME")
           HTTP_CODE=$(curl -sf -o /dev/null -w '%{http_code}' "http://${CONTAINER_IP}:${CONTAINER_PORT}/" 2>/dev/null || true)
-          if [ "$HTTP_CODE" != "200" ]; then
-            echo "ERROR: Smoke test failed (HTTP $HTTP_CODE)"
-            docker logs --tail 30 "$CONTAINER_NAME"
-            exit 1
+          if [ "${HTTP_CODE:-000}" != "200" ]; then
+            fail_deploy "internal smoke test HTTP ${HTTP_CODE:-000}"
           fi
 
           echo "=== Public checklist smoke ==="
@@ -172,8 +203,7 @@ jobs:
               fi
             done
 
-            echo "ERROR: Public checklist smoke failed for ${endpoint}"
-            return 1
+            fail_deploy "public checklist ${endpoint} failed"
           }
 
           check_public_endpoint "/healthz"
@@ -189,7 +219,8 @@ jobs:
           curl -fsS --get "https://api.indexnow.org/indexnow" \
             --data-urlencode "url=${PUBLIC_ORIGIN}/" \
             --data-urlencode "key=${INDEXNOW_KEY}" \
-            -o /dev/null
+            -o /dev/null ||
+            echo "WARNING: IndexNow submission failed; deployment remains healthy."
 
           echo "=== Deploy successful ==="
           echo "Image:  $(docker inspect --format='{{.Config.Image}}' "$CONTAINER_NAME")"
@@ -198,3 +229,4 @@ jobs:
 
           echo "=== GHCR logout ==="
           docker logout ghcr.io
+          trap - EXIT

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,15 +48,15 @@ jobs:
           exit 1
 
       - name: Checkout target
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           ref: ${{ inputs.target }}
           fetch-depth: 0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
-          node-version: "24"
+          node-version: "lts/*"
           cache: npm
           cache-dependency-path: app/package-lock.json
 

--- a/.github/workflows/signature-pr.yml
+++ b/.github/workflows/signature-pr.yml
@@ -33,19 +33,19 @@ jobs:
       # action_required, so the required `build` check never reports and the
       # signature PR can never merge. An App installation token is a distinct
       # actor, so the run starts on its own.
-      - uses: actions/create-github-app-token@v3
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         id: app-token
         with:
           app-id: ${{ vars.SIGNATURE_BOT_APP_ID }}
           private-key: ${{ secrets.SIGNATURE_BOT_PRIVATE_KEY }}
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           token: ${{ steps.app-token.outputs.token }}
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
-          node-version: '24'
+          node-version: 'lts/*'
 
       - name: Read signature request
         id: request

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -20,14 +20,14 @@ jobs:
       run:
         working-directory: app
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           # Full history so the signature-date generator (prebuild) can read
           # each signatory file's add commit.
           fetch-depth: 0
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
-          node-version: '24'
+          node-version: 'lts/*'
           cache: 'npm'
           cache-dependency-path: app/package-lock.json
       - run: npm ci

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,7 +78,7 @@ app/
 - `api-routes.md` — JSON in/out, validation stricte, contrats versionnés.
 - `store-provider.md` — interface-first, swappable, framework-agnostic.
 - `styles-tokens.md` — `oklch()` uniquement, pas de hex/HSL hors `tokens.css`.
-- `docker.md` — multi-stage Node 22 alpine, non-root, port 4321.
+- `docker.md` — multi-stage Node LTS sur Debian Trixie slim, non-root, port 4321.
 - `testing.md` — Vitest unit + Playwright e2e + régression visuelle du cover ≤ 1 % (snapshot Astro, plus de baseline).
 
 ## Conventions

--- a/aidd_docs/rules/architecture/docker.md
+++ b/aidd_docs/rules/architecture/docker.md
@@ -4,8 +4,9 @@
 `app/Dockerfile`, `app/compose.yaml`, `app/.dockerignore`.
 
 ## Hard rules
-- Base image: `node:22-alpine` (build + runtime).
-- Multi-stage: `deps` → `build` → `runner`. Production image runs as a non-root user.
+- Base image: `node:lts-trixie-slim` (build + runtime).
+- Multi-stage: `base` → `prod-deps` / `build-deps` → `build` → `runner`.
+  Production runs as the explicit non-root UID/GID `1001:1001`.
 - `runner` stage installs only production dependencies.
 - Container listens on `4321`. Compose maps host `4321:4321`.
 - `HOST=0.0.0.0`, `PORT=4321`, `NODE_ENV=production` set in the runner stage.

--- a/app/.npmrc
+++ b/app/.npmrc
@@ -1,0 +1,1 @@
+strict-allow-scripts=true

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -2,7 +2,7 @@
 #
 # Astro 6 SSR (Node standalone adapter) — multi-stage build.
 # Compliant with aidd_docs/rules/architecture/docker.md:
-#   - Multi-stage: deps → build → runner
+#   - Multi-stage: base → prod-deps / build-deps → build → runner
 #   - Runner runs prod-only node_modules (no devDeps)
 #   - Non-root USER with explicit UID/GID matching compose `user: 1001:1001`
 #   - HOST=0.0.0.0, PORT=4321, NODE_ENV=production
@@ -10,34 +10,38 @@
 # Image is built and pushed to ghcr.io/ai-driven-dev/manifest by the
 # .github/workflows/deploy.yml pipeline (self-hosted runner on AIDD).
 
-# ── Production dependencies (runner) ─────────────────────────────
-FROM node:24-alpine AS prod-deps
+# ── Shared build base ─────────────────────────────────────────────
+FROM node:lts-trixie-slim AS base
 WORKDIR /app
-COPY package.json package-lock.json* ./
+COPY package.json ./
+RUN npm install --global "$(node -p "require('./package.json').packageManager")"
+
+# ── Production dependencies (runner) ─────────────────────────────
+FROM base AS prod-deps
+COPY package.json package-lock.json* .npmrc ./
 RUN npm ci --omit=dev --no-audit --no-fund
 
 # ── All dependencies (build stage needs Astro CLI = devDep) ──────
-FROM node:24-alpine AS build-deps
-WORKDIR /app
-COPY package.json package-lock.json* ./
+FROM base AS build-deps
+COPY package.json package-lock.json* .npmrc ./
 RUN npm ci --no-audit --no-fund
 
 # ── Build ────────────────────────────────────────────────────────
-FROM node:24-alpine AS build
-WORKDIR /app
+FROM base AS build
 COPY --from=build-deps /app/node_modules ./node_modules
 COPY . .
 RUN npm run build
 
 # ── Runner ───────────────────────────────────────────────────────
-FROM node:24-alpine AS runner
+FROM node:lts-trixie-slim AS runner
 WORKDIR /app
 ENV NODE_ENV=production \
     HOST=0.0.0.0 \
     PORT=4321
 
 # Explicit UID/GID 1001:1001 to match compose `user: "1001:1001"`.
-RUN addgroup -g 1001 -S app && adduser -u 1001 -S app -G app
+RUN groupadd --gid 1001 app \
+    && useradd --uid 1001 --gid app --no-create-home --shell /usr/sbin/nologin app
 
 COPY --from=prod-deps --chown=app:app /app/node_modules ./node_modules
 COPY --from=build     --chown=app:app /app/dist          ./dist

--- a/app/package.json
+++ b/app/package.json
@@ -4,6 +4,7 @@
   "version": "0.1.0",
   "license": "MIT",
   "private": true,
+  "packageManager": "npm@12.0.1",
   "engines": {
     "node": ">=24"
   },
@@ -32,5 +33,10 @@
     "playwright": "^1.48.2",
     "typescript": "^5.6.3",
     "vitest": "4.1.8"
+  },
+  "allowScripts": {
+    "esbuild": true,
+    "fsevents": false,
+    "sharp": true
   }
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    "helpers:pinGitHubActionDigests",
+    ":dependencyDashboard"
+  ],
+  "timezone": "Europe/Paris",
+  "schedule": ["before 8am on Monday"],
+  "prConcurrentLimit": 1,
+  "branchConcurrentLimit": 1,
+  "prHourlyLimit": 1,
+  "rangeStrategy": "bump",
+  "automerge": true,
+  "automergeType": "pr",
+  "automergeStrategy": "squash",
+  "platformAutomerge": false,
+  "ignoreTests": false,
+  "labels": ["dependencies"],
+  "packageRules": [
+    {
+      "matchManagers": ["npm", "dockerfile", "docker-compose", "github-actions"],
+      "groupName": "weekly dependencies",
+      "groupSlug": "weekly-dependencies"
+    }
+  ],
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 8am on Monday"],
+    "automerge": true
+  },
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "schedule": ["at any time"],
+    "automerge": true
+  }
+}


### PR DESCRIPTION
## Résumé
- passe le runtime sur Node LTS Trixie slim en non-root
- ajoute un healthcheck applicatif sans dépendance système
- épingle les actions GitHub et prépare Renovate
- conserve un rollback de déploiement explicite

## Validation
- build et 53 tests OK
- actionlint et configuration Renovate OK
- image Docker : Node 24.18, Debian Trixie, UID 1001
- `/healthz` retourne 200