### PR TITLE
fix(signature): accept LinkedIn URLs pasted without a scheme

### DIFF
--- a/.github/scripts/read-signature-request.js
+++ b/.github/scripts/read-signature-request.js
@@ -19,6 +19,8 @@ const FIELD = Object.freeze({
 });
 
 const GITHUB_HANDLE_RE = /^[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,37}[a-zA-Z0-9])?$/;
+const SCHEME_RE = /^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//;
+const DOMAIN_START_RE = /^[^\s/?#]+\.[^\s/?#]+/;
 
 function clean(value) {
   return String(value ?? '')
@@ -85,13 +87,25 @@ function validateGithubHandle(value) {
   return github;
 }
 
+// Signers routinely paste the URL LinkedIn shows them, which has no scheme
+// (`www.linkedin.com/in/handle`). Prefixing `https://` unconditionally would
+// turn any typo into a hostname, so only a value that starts with a dotted
+// domain is completed.
+function withScheme(url) {
+  if (SCHEME_RE.test(url)) return url;
+  return DOMAIN_START_RE.test(url) ? `https://${url}` : url;
+}
+
 function validateLinkedIn(value) {
-  const url = optionalText(value, 'linkedin');
-  if (!url) return '';
+  const text = clean(value);
+  if (!text || text === NO_RESPONSE) return '';
+
+  const url = withScheme(checkOneLine(text, 'linkedin'));
 
   try {
     const parsed = new URL(url);
-    if (['http:', 'https:'].includes(parsed.protocol)) return url;
+    // The completed URL is what gets stored, so the limit applies to it.
+    if (['http:', 'https:'].includes(parsed.protocol)) return checkLength(url, 'linkedin');
   } catch {}
   throw new Error('linkedin must be a valid URL');
 }

--- a/.github/scripts/read-signature-request.test.js
+++ b/.github/scripts/read-signature-request.test.js
@@ -143,6 +143,22 @@ describe('signature request reader behavior', () => {
     assert.match(result.stderr, /name is required/);
   });
 
+  it('completes a scheme-less LinkedIn profile into the public URL stored in the YAML', () => {
+    const { outputs } = runRequestReader(signatureIssueEvent({
+      body: issueFormBody({ 'LinkedIn profile': 'www.linkedin.com/in/octocat-059b3725' }),
+    }));
+
+    assert.equal(outputs.linkedin_yaml, '"https://www.linkedin.com/in/octocat-059b3725"');
+  });
+
+  it('completes a scheme-less LinkedIn profile that omits the www subdomain', () => {
+    const { outputs } = runRequestReader(signatureIssueEvent({
+      body: issueFormBody({ 'LinkedIn profile': 'linkedin.com/in/octocat' }),
+    }));
+
+    assert.equal(outputs.linkedin_yaml, '"https://linkedin.com/in/octocat"');
+  });
+
   it('fails a signer issue when the LinkedIn field cannot become a public URL', () => {
     const result = failRequestReader(signatureIssueEvent({
       body: issueFormBody({ 'LinkedIn profile': 'not-a-url' }),


### PR DESCRIPTION
## Problem

LinkedIn displays profile URLs without a scheme (`www.linkedin.com/in/handle`), and signers paste exactly that into the Issue Form. `validateLinkedIn` called `new URL(value)`, which throws on a scheme-less string, so the whole request was rejected, labelled `signature-needs-fix` and closed.

Reported in #193 (`www.linkedin.com/in/yoann-gauchard-059b3725`).

## Fix

Complete a scheme-less value with `https://`, but only when it starts with a dotted domain. An unconditional prefix would make `not-a-url` parse as a hostname and silently store a broken link — the existing test for that case still passes.

The completed URL is what ends up in the YAML, so the 200-char limit is now applied after completion instead of before.

## Verification

- `node --test .github/scripts/read-signature-request.test.js` — 11/11, including two new cases (`www.linkedin.com/in/…` and `linkedin.com/in/…`).
- Dry-run against the real payload of #193 now succeeds and emits `linkedin: "https://www.linkedin.com/in/yoann-gauchard-059b3725"`, which satisfies the `z.string().url()` constraint in `app/src/content.config.ts`.

## Follow-up

After merge, #193 can be reprocessed with `gh issue reopen 193` then adding the `signature-retry` label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014uZAKzCi1MSQBc2zA8fPhx